### PR TITLE
Fix This Week in Solid links

### DIFF
--- a/_posts/this-week-in-solid/2019-01-01-this-week-in-solid.md
+++ b/_posts/this-week-in-solid/2019-01-01-this-week-in-solid.md
@@ -12,7 +12,7 @@ You can always check here for the most current issue as well as find a record of
 
 # Next Up
 
-We're currently working on next week's edition. You can contribute by [making a Pull Request](https://github.com/solid/solid.github.io/edit/master/_posts/this-week-in-solid/next.md)!
+We're currently working on next week's edition. You can contribute by [making a Pull Request](https://github.com/solid/solidproject.org/edit/master/_posts/this-week-in-solid/next.md)!
 
 # Past Issues
 

--- a/_posts/this-week-in-solid/2019-10-31-this-week-in-solid.md
+++ b/_posts/this-week-in-solid/2019-10-31-this-week-in-solid.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: Welcome to another edition
-permalink: /weekly-updates/next
+permalink: /this-week-in-solid/next
 tags: [weekly, updates]
 categories: [Updates]
 author: Mitzi László

--- a/_posts/this-week-in-solid/2019-11-07-this-week-in-solid.md
+++ b/_posts/this-week-in-solid/2019-11-07-this-week-in-solid.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: Welcome to another edition
-permalink: /weekly-updates/next
+permalink: /this-week-in-solid/next
 tags: [weekly, updates]
 categories: [Updates]
 author: Mitzi László

--- a/_posts/this-week-in-solid/2019-11-14-this-week-in-solid.md
+++ b/_posts/this-week-in-solid/2019-11-14-this-week-in-solid.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: Welcome to another edition
-permalink: /weekly-updates/next
+permalink: /this-week-in-solid/next
 tags: [weekly, updates]
 categories: [Updates]
 author: Mitzi László

--- a/_posts/this-week-in-solid/next.md
+++ b/_posts/this-week-in-solid/next.md
@@ -1,7 +1,7 @@
 ---
 layout: blog
 title: Welcome to another edition
-permalink: /weekly-updates/next
+permalink: /this-week-in-solid/next
 tags: [weekly, updates]
 categories: [Updates]
 author: Mitzi László


### PR DESCRIPTION
The pages were at /weekly-updates, isntead of /this-week-in-solid.
Additionally, the link to submit a pull request was pointing to the
solid.github.io repo, while TWiS is being compiled on the
solidproject.org repository.

(Note that the rest of development on the website still happens
on the solid.github.io repository.)