### PR TITLE
Fix link to specification on home page

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -135,10 +135,10 @@ permalink: /
       <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7">
         <div class="info-card">
           <h3 class="title">
-            <a href="https://solidproject.org/specification/">Solid is a standard</a>
+            <a href="https://solid.github.io/specification/">Solid is a standard</a>
           </h3>
           <p class="info">
-            The web was designed to make it possible for information – data – to transfer conveniently no matter where you are or what device you are using. Today data is used as a bargaining chip to lock you in. <a href="https://solidproject.org/specification/" title="The Solid Specification">Solid is a standard</a> that describes how to build storage, apps, and identification in such a way that you can conveniently connect and switch without losing data. If you are interested in the standardisation process, <a href="{{site.baseUrl}}/standardisation" title="How to contribute to the Solid standards">contributions are welcome</a>.
+            The web was designed to make it possible for information – data – to transfer conveniently no matter where you are or what device you are using. Today data is used as a bargaining chip to lock you in. <a href="https://solid.github.io/specification/" title="The Solid Specification">Solid is a standard</a> that describes how to build storage, apps, and identification in such a way that you can conveniently connect and switch without losing data. If you are interested in the standardisation process, <a href="{{site.baseUrl}}/standardisation" title="How to contribute to the Solid standards">contributions are welcome</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
These two links currently result in a 404 since `/specification` doesn't exist.

I'm not actually sure what the right location is, but since the same paragraph links to `/standardisation` as well, I *assume* the others should link to the specification.

Let me know if I should change anything or feel free to close it if you have a better solution.