### PR TITLE
Rewrite standards copy for accuracy

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -56,12 +56,18 @@ permalink: /
       <div class="col-xs-12 col-sm-12 col-md-7 col-lg-7">
         <div class="info-card">
           <h3 class="title">
-            Not a company, not a product, just a standard
+            Open specifications built on open standards
           </h3>
           <p class="info">
-          Solid is an <a href="https://solid.github.io/specification/">open standard</a>, meaning that anyone can implement it.
-          It describes how <a href="{{site.baseUrl}}/faqs#pod" title="Frequently Asked Questions - what is a Pod?">Pods</a>, <a href="{{site.baseUrl}}/faqs#webid" title="Frequently Asked Questions - what is a WebID?">WebIDs</a> and apps interact to <a href="{{site.baseUrl}}/faqs#interoperability" title="Frequently Asked Questions - What does 'Interoperability' mean?">interoperate</a>.
-          The Web makes it possible to transfer data conveniently and Solid adds a user-centric access control.
+           Websites, you can browse them on any device
+           and with a browser you choose.
+           Solid gives you that same choice, but for <em>data</em>:
+           you can pick the apps you trust
+           to handle your personal data.
+           To realize such unprecedented interoperability,
+           Solid uses the same recipe as the Web:
+           following <a href="https://solid.github.io/specification/">open standards and specifications</a>.
+           Anyone is welcome to <a href="{{site.baseUrl}}/standardisation">join the standardisation process</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
The current homepage copy is inaccurate regarding the relation between Solid and standards/specifications. We should be careful to not spread misinformation.

This PR replaces the current version with a text that is technically accurate. Changes to phrasing etc. are definitely welcome; we just need to ensure that what we write down is truthful.

Once this PR is accepted, I will open a PR to adjust other places (such as the "This week in Solid" newsletter opening copy accordingly), to avoid further spread of the inaccurate version.

-----

## FAQ

**Q1: Why is Solid not a standard?**
Solid operates under a W3C Community Group. W3C states the following regarding its standards:

> W3C publishes Recommendations, which are considered Web standards.

> W3C also publishes **other technical reports that are not standards**. […]

> […] In some cases, these documents serve as input to the standards process. Common sources of input to the standards process include:
>
> - W3C Member Submissions, a benefit of W3C Membership
> - **W3C Community and Business Groups**

—https://www.w3.org/standards/faq#std (emphasis mine)

So calling Solid a "standard" puts out outside of W3C.

**Q2: What is the relationship between Solid and standards?**

Solid _uses_ open Web standards, including URL, HTTP, LDP, RDF.

**Q3: What are the documents produced by the Solid process?**

They are technical specifications.

For a background on Internet Standards and specifications, please see https://tools.ietf.org/html/rfc1310