### PR TITLE
Add link to GitHub issues for website feedback

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -36,3 +36,5 @@
     link: "/license"
   - name: Logo usage guidelines
     link: "/logo-usage-guidelines"
+  - name: Website feedback
+    link: "https://github.com/solid/solidproject.org/issues/new"


### PR DESCRIPTION
To make it clear where people can direct feedback on the website, this adds a link to the footer directing people to GitHub issues.