### PR TITLE
Replace archived repo with maintained cheatsheet

### DIFF
--- a/_posts/for-developers/apps/tools/2020-01-25_overview.md
+++ b/_posts/for-developers/apps/tools/2020-01-25_overview.md
@@ -42,7 +42,7 @@ Beginning developers may want to start with one of the interface libraries which
      * [Soukai-solid](https://github.com/NoelDeMartin/soukai-solid)
      * [Tripledoc](https://vincenttunru.gitlab.io/tripledoc/)
 
-See also [solid-lib-comparison](https://github.com/inrupt/solid-lib-comparison) for a handy comparison between three commonly used linked data libraries.
+See also [this cheatsheet](https://vincenttunru.gitlab.io/tripledoc/docs/cheatsheet) for a handy comparison between three commonly used linked data libraries.
 
 
   * <a name="resource">**Resource  Management Libraries**</a>


### PR DESCRIPTION
The tools page looks great @jeff-zucker. However, I'm not maintaining [solid-lib-comparison](https://github.com/inrupt/solid-lib-comparison) - it was merely a dump of a live coding demo at a meetup, and is now archived. I'd propose [my cheatsheet](https://vincenttunru.gitlab.io/tripledoc/docs/cheatsheet) to serve as a comparison, as I'm actually maintaining that. What do you think?