### PR TITLE
Fix changed PLDN links

### DIFF
--- a/_posts/this-week-in-solid/2019-10-31-this-week-in-solid.md
+++ b/_posts/this-week-in-solid/2019-10-31-this-week-in-solid.md
@@ -25,10 +25,10 @@ Next weeks call will be on the 7th November at 1600 CEST on [this line](https://
 
 * [The Wall Street Journal - Tech Giants Have Hijacked the Web. It’s Time for a Reboot by Paul Vigna](https://www.wsj.com/articles/tech-giants-have-hijacked-the-web-its-time-for-a-reboot-11572062420) 
 * [Summary of the Data Ethics conference](https://mailchi.mp/dit.dk/data-ethics-2019-inspiration1) where Mitzi László gave a talk on Solid. 
-* [Summary of Solid Amsterdam](http://www.pilod.nl/wiki/Solid_Amsterdam_–_1st_Session_Summary) 
+* [Summary of Solid Amsterdam](https://www.pldn.nl/index.php/Solid_Amsterdam_–_1st_Session_Summary)
 
 There are few upcoming events where you can learn more and meet others working on Solid: 
-* 2019-12-10 [Solid Enschede](http://www.pilod.nl/wiki/Solid_Christmas_Meetup_Enschede_-_How_to_Fix_the_Internet!) organised by Erwin Folmer
+* 2019-12-10 [Solid Enschede](https://www.pldn.nl/index.php/Solid_Christmas_Meetup_Enschede_-_How_to_Fix_the_Internet!) organised by Erwin Folmer
 * 2019-11-20 [Solid London](https://www.eventbrite.com/e/data-control-ethics-solid-workshop-this-is-for-everyone-join-the-movement-tickets-79208132657?ref=estw) organised by Kartika Tulusan
 
 Solid Events are run by people like you, read more about tips on organising a successful Solid events [here](https://github.com/solid/information/blob/master/solid-events.md)

--- a/_posts/this-week-in-solid/2019-11-07-this-week-in-solid.md
+++ b/_posts/this-week-in-solid/2019-11-07-this-week-in-solid.md
@@ -23,7 +23,7 @@ There are few upcoming events where you can learn more and meet others working o
 * 2019-11-14 Mitzi László will be speaking at the [ECP Jaarcongres](https://ecp.nl/jaarcongres/programma/#event-158) in the Hague 
 * 2019-11-20 [Solid London](https://www.eventbrite.com/e/data-control-ethics-solid-workshop-this-is-for-everyone-join-the-movement-tickets-79208132657?ref=estw) organised by Kartika Tulusan
 * 2019-11-21 [Solid Montreal](https://www.meetup.com/Montreal-Decentralized-Linked-Data-Meetup/events/266218723/?fbclid=IwAR2sJy5LIwzjJG52HSyfj88TSW4t5w_svUsWKA-STNG_e-pwrkfoLC5ROpE) organised by [David H Manson](https://github.com/vid)|
-* 2019-12-10 [Solid Enschede](http://www.pilod.nl/wiki/Solid_Christmas_Meetup_Enschede_-_How_to_Fix_the_Internet!) organised by Erwin Folmer
+* 2019-12-10 [Solid Enschede](https://www.pldn.nl/index.php/Solid_Christmas_Meetup_Enschede_-_How_to_Fix_the_Internet!) organised by Erwin Folmer
 * 2019-01-xx (date to be confirmed) Solid Amsterdam organised by [Jeroen van Beele](https://github.com/jjvbeele)
 
 Solid Events are run by people like you, read more about tips on organising a successful Solid events [here](https://github.com/solid/information/blob/master/solid-events.md). Have you seen any articles or talks about Solid this week? If you've seen any talks, articles, or written blog posts about Solid please do send them over for next week.

--- a/_posts/this-week-in-solid/2019-11-14-this-week-in-solid.md
+++ b/_posts/this-week-in-solid/2019-11-14-this-week-in-solid.md
@@ -33,7 +33,7 @@ There are few upcoming events where you can learn more and meet others working o
 * 2019-11-14 Mitzi László will be speaking at the [ECP Jaarcongres](https://ecp.nl/jaarcongres/programma/#event-158) in the Hague 
 * 2019-11-20 [Solid London](https://www.eventbrite.com/e/data-control-ethics-solid-workshop-this-is-for-everyone-join-the-movement-tickets-79208132657?ref=estw) organised by Kartika Tulusan
 * 2019-11-21 [Solid Montreal](https://www.meetup.com/Montreal-Decentralized-Linked-Data-Meetup/events/266218723/?fbclid=IwAR2sJy5LIwzjJG52HSyfj88TSW4t5w_svUsWKA-STNG_e-pwrkfoLC5ROpE) organised by [David H Manson](https://github.com/vid)|
-* 2019-12-10 [Solid Enschede](http://www.pilod.nl/wiki/Solid_Christmas_Meetup_Enschede_-_How_to_Fix_the_Internet!) organised by Erwin Folmer
+* 2019-12-10 [Solid Enschede](https://www.pldn.nl/index.php/Solid_Christmas_Meetup_Enschede_-_How_to_Fix_the_Internet!) organised by Erwin Folmer
 * 2019-01-xx (date to be confirmed) Solid Amsterdam organised by [Jeroen van Beele](https://github.com/jjvbeele)
 
 Solid Events are run by people like you, read more about tips on organising a successful Solid events [here](https://github.com/solid/information/blob/master/solid-events.md). Have you seen any articles or talks about Solid this week? If you've seen any talks, articles, or written blog posts about Solid please do send them over for next week.

--- a/_posts/this-week-in-solid/2019-11-28-this-week-in-solid.md
+++ b/_posts/this-week-in-solid/2019-11-28-this-week-in-solid.md
@@ -11,7 +11,7 @@ author: Mitzi László
 
 ## [Press](https://solidproject.org/press)
 
-Check out a recap of the talk at ECP from last week [here](http://www.pilod.nl/wiki/Jaarcongres_ECP_2019_-_Solid_Session_Summary).
+Check out a recap of the talk at ECP from last week [here](https://www.pldn.nl/index.php/Jaarcongres_ECP_2019_-_Solid_Session_Summary).
 
 There's also a article that mentions Solid on the [LSE Business Review](https://blogs.lse.ac.uk/businessreview/2019/11/20/how-to-turn-trust-into-a-competitive-advantage/)
 

--- a/_posts/this-week-in-solid/next.md
+++ b/_posts/this-week-in-solid/next.md
@@ -21,7 +21,7 @@ At the [P2P Festival in Paris](https://p2p.paris/fr/event/festival-0/) there was
 
 Michiel de Jong presented on the [Workshop on Cloud Services for File Synchronisation and Sharing](https://cs3.deic.dk) on the 27th of January. 
 
-[Solid Amsterdam](http://www.pilod.nl/wiki/2nd_Solid_Amsterdam_Meetup_%E2%80%93_January_30th,_2020) led by Jeroen van Beele had another event on the 30th January. 
+[Solid Amsterdam](https://www.pldn.nl/index.php/2nd_Solid_Amsterdam_Meetup_%E2%80%93_January_30th,_2020) led by Jeroen van Beele had another event on the 30th January.
 
 There are a few upcoming events where you can learn more and meet others working on Solid: 
 

--- a/pages/press.md
+++ b/pages/press.md
@@ -266,7 +266,7 @@ Are you looking to get a speaker or interview about Solid? Contact us on press@s
   include talk.html
     date="2019-04-09"
     title="Platform Linked Data Nederland"
-    website="http://www.pilod.nl/wiki/PLDN-Solid_Kick-Off_–_April_9th_2019"
+    website="https://www.pldn.nl/index.php/PLDN-Solid_Kick-Off_–_April_9th_2019"
     speaker="Ruben Verborgh"
     slides="https://rubenverborgh.github.io/PLDN-Solid-Kick-Off-2019/"
 %}

--- a/pages/solid-events.md
+++ b/pages/solid-events.md
@@ -12,7 +12,7 @@ Solid Events are an opportunity for the Solid community to meet in person locall
 | Date | Event | Organiser(s) |
 |------|-------|--------------|
 |2020-01-07|[Solid Khartoum](http://solid-khartoum.atspace.cc)|[Ali Siragedien](https://github.com/alisirag)|
-|2020-01-30|[Solid Amsterdam](http://www.pilod.nl/wiki/2nd_Solid_Amsterdam_Meetup_–_January_30th,_2020)|[Jeroen van Beele](https://github.com/jjvbeele) |
+|2020-01-30|[Solid Amsterdam](https://www.pldn.nl/index.php/2nd_Solid_Amsterdam_Meetup_–_January_30th,_2020)|[Jeroen van Beele](https://github.com/jjvbeele) |
 
 (past events are [listed below](#past-events))
 
@@ -111,7 +111,7 @@ The third Solid Event is a good place to gather local companies and institutions
 | 2019-05-08 | [Solid New York](https://www.meetup.com/NextWeb-NYC/) | Brian Cort ||
 | 2019-05-02 | [Solid Seattle](https://www.eventbrite.com/e/solid-seattle-tickets-60131990402) | [Jon Pederson](https://www.linkedin.com/in/jonpederson/) ||
 | 2019-04-09 | [Solid San Jose](https://www.meetup.com/San-Jose-SOLID-Technology-decentralized-Web-Meetup/events/260087036/) | [John Bartas](http://www.bartas.net/resume.html) ||
-| 2019-04-09 | [Solid Utrecht](http://www.pilod.nl/wiki/PLDN-Solid_Kick-Off_%E2%80%93_April_9th_2019) | [Pieter van Everdingen](https://www.linkedin.com/in/pietervaneverdingen/) ||
+| 2019-04-09 | [Solid Utrecht](https://www.pldn.nl/index.php/PLDN-Solid_Kick-Off_%E2%80%93_April_9th_2019) | [Pieter van Everdingen](https://www.linkedin.com/in/pietervaneverdingen/) ||
 | 2019-03-27 | [Solid Berlin](https://www.eventbrite.com/e/solid-meetup-berlin-tickets-55479654139) | [Christian Buggedei](https://github.com/JollyOrc) ||
 | 2019-03-22 | [Solid Boston](https://www.eventbrite.com/e/solid-startup-workshop-boston-tickets-57623868542) | [Kelly O'Brien](https://github.com/InruptKelly) ||
 | 2019-03-21 | [Solid Boston](https://www.eventbrite.com/e/solid-boston-tickets-57623377072) | [Kelly O'Brien](https://github.com/InruptKelly) ||


### PR DESCRIPTION
Apparently they moved their website to pldn.nl from pilod.nl, which is why our automated checks for broken links are failing...