### PR TITLE
Remove broken "API Best in Class" link

### DIFF
--- a/pages/press.md
+++ b/pages/press.md
@@ -774,7 +774,7 @@ Apple joins Google, Facebook, and Twitter in data-sharing project](https://myjoy
 
 2019-03-17 [The Times: Tim Berners-Lee calls for a fight for ‘the kind of web we want’](https://www.thetimes.co.uk/edition/news-review/tim-berners-lee-calls-for-a-fight-for-the-kind-of-web-we-want-wk95rjxls)
 
-2019-03-15 [API Best in Class: What is Solid? Decentralized Web? Tim Berners-Lee is up to something again.](https://apibestinclass.com/what-is-solid-decentralized-web-tim-berners-lee-is-up-to-something-again/)
+2019-03-15 API Best in Class: What is Solid? Decentralized Web? Tim Berners-Lee is up to something again.
 
 2019-03-14 [Fast Company: T Bone Burnett rips Big Tech “surveillance capitalists” in blistering SXSW keynote](https://www.fastcompany.com/90320480/full-text-t-bone-burnett-rips-big-tech-surveillance-capitalists-in-blistering-sxsw-keynote)
 


### PR DESCRIPTION
It results in 404 and is not available in the Web Archive: http://web.archive.org/web/*/https://apibestinclass.com/what-is-solid-decentralized-web-tim-berners-lee-is-up-to-something-again/