### PR TITLE
Lock the yaspeller version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ script:
       --typhoeus_config '{"timeout":60}'
       --http-status-ignore '0,301,302,403,410,429,500,501,502,503,522,999'
       _site
+  # Lock the yaspeller version.
+  # This will prevent our builds from suddenly failing if yaspeller
+  # e.g. (purely hypothetically *cough*) adds a fuzzier typo checker.
+  - npm install yaspeller@6.0.*
+  - npm install yaspeller-ci@1.0.2
   - npx yaspeller-ci --dictionary dictionary.json **/*.md _site
 
 before_deploy:


### PR DESCRIPTION
This will prevent our builds from suddenly failing if yaspeller
e.g. (purely hypothetically *cough*) adds a fuzzier typo checker.

Note: it's not hypothetical, our build is currently broken because yaspeller is apparently interpreting `**WebID** is` as `WebID  is` (i.e. with two spaces), which is something different from the word in our dictionary (`WebID is`).

We could work around that some time, but at a time of our choosing, rather than the build suddenly breaking while we were working on other things. Hence, the locked version.