### PR TITLE
Sort entries on the funding page alphabetically

### DIFF
--- a/pages/funding.md
+++ b/pages/funding.md
@@ -7,17 +7,17 @@ permalink: funding
 # Funding
 If you know of any grants or channels to apply to resources that would allow developers to focus on building their Solid applications, please do share them on this list by [submitting a pull request](https://github.com/solid/solidproject.org/blob/staging/pages/funding.md) or by emailing the Solid Manager on info@solidproject.org.  
 
-* [Je Data de Baas](https://www.sidnfonds.nl/nieuws/follow-up-call-je-data-de-baas) by SIDN
-* [EU DAPSI](https://dapsi.ngi.eu/)
-* [NGI Pointer](https://www.ngi.eu/ngi-projects/ngi-pointer/)
-* [GitHub Sponsors](https://github.com/sponsors)
-* [DuckDuckGo Donations](https://duckduckgo.com/donations)
-* [The Knight Foundation](https://knightfoundation.org) and [The Knight Foundation for Technology Innovation](https://knightfoundation.org/programs/technology)
-* [SIDN Fonds](https://www.sidnfonds.nl/excerpt/)
-* [Next Generation Internet](https://www.ngi.eu)
-* [NLNET Foundation](https://nlnet.nl)
 * [Consensus Community Innovation Grants](http://agree.org/)
-* [Slack Fund](https://slack.com/developers/fund)
+* [DuckDuckGo Donations](https://duckduckgo.com/donations)
+* [EU DAPSI](https://dapsi.ngi.eu/)
+* [GitHub Sponsors](https://github.com/sponsors)
+* [Je Data de Baas](https://www.sidnfonds.nl/nieuws/follow-up-call-je-data-de-baas) by SIDN
+* [Ledger Project](https://ledgerproject.eu)
 * [Mozilla Open Science Mini Grants](https://docs.google.com/document/d/1EJXg9G01CG7dBRbmbZzFnB9Bex2ibAVza_4xE8iqQqI/edit)
 * [Mozilla Open Source Support](https://www.mozilla.org/en-US/moss/)
-* [Ledger Project](https://ledgerproject.eu)
+* [NGI Pointer](https://www.ngi.eu/ngi-projects/ngi-pointer/)
+* [NLNET Foundation](https://nlnet.nl)
+* [Next Generation Internet](https://www.ngi.eu)
+* [SIDN Fonds](https://www.sidnfonds.nl/excerpt/)
+* [Slack Fund](https://slack.com/developers/fund)
+* [The Knight Foundation](https://knightfoundation.org) and [The Knight Foundation for Technology Innovation](https://knightfoundation.org/programs/technology)


### PR DESCRIPTION
The order of entries on the funding page seems a bit [hodge-podge](https://en.wikipedia.org/wiki/Hodge-podge).

This merge-request remedies that by sorting them in alphabetical order.
