### PR TITLE
Pod Provider Link not Loading

### DIFF
--- a/pages/use-solid.md
+++ b/pages/use-solid.md
@@ -34,7 +34,6 @@ You can pick a Provider in the following list. However, keep in mind that Solid 
 | Provider | Responsible for Domain Name and Terms | Responsible for Hosting | Location of Hosting |
 |-----------------------------------|:---------------------------------------------------:|:-------------------------------------------------:|:-------------------:|:--------------------:|
 | [inrupt.net](https://inrupt.net) | [Inrupt, Inc.](https://inrupt.com/terms-of-service) | [Amazon](https://aws.amazon.com) | USA |
-| [solid.authing.cn](https://solid.authing.cn) | [Authing](https://authing.cn) | [Tencent Cloud](https://cloud.tencent.com) | China |
 
 If you are a provider you can add your service to this list by emailing [info@solidproject.org](mailto:info@solidproject.org).
 


### PR DESCRIPTION
https://solid.authing.cn is resulting in a 504 Gateway Time-out error page. With this pull request, I propose to de-list the Pod provider until the link is repaired.