### PR TITLE
Fix syntax error in press listing

### DIFF
--- a/pages/press.md
+++ b/pages/press.md
@@ -714,7 +714,7 @@ Are you looking to get a speaker or interview about Solid? Contact us on [press@
 
 2020-01-23 [Developer offers a glimpse of what a ‘Solid’ decentralized social network presence might look like](https://www.coywolf.news/social/solid-profile-design/)
 
-2020-01-22 [The Inventor of the World Wide Web wrote an Inspiring Letter to the Women’s Technology Empowerment Centre in Lagos | Read it Here](https://www.bellanaija.com/2020/01/tim-berners-lees/)
+2020-01-22 [The Inventor of the World Wide Web wrote an Inspiring Letter to the Women’s Technology Empowerment Centre in Lagos \| Read it Here](https://www.bellanaija.com/2020/01/tim-berners-lees/)
 
 2020-01-20 [Freeing the Web From Big Tech](https://www.thenewamerican.com/print-magazine/item/34519-freeing-the-web-from-big-tech)
 


### PR DESCRIPTION
The `|` in the text made Jekyll think that it was a table row, which it was not:

![image](https://user-images.githubusercontent.com/4251/90387375-55538d80-e086-11ea-848b-9023907b1283.png)
