### PR TITLE
New edition of newsletter

### DIFF
--- a/_posts/newsletter/2020-09-03-this-month-in-solid.md
+++ b/_posts/newsletter/2020-09-03-this-month-in-solid.md
@@ -1,0 +1,29 @@
+---
+layout: newsletter
+title: This Month in Solid 2020-09-03
+permalink: /newsletter/2020-09-03
+tags: [monthly, updates]
+categories: [Updates]
+---
+{% include twis-intro.md %}
+
+## Updates
+
+### [Events](https://solidproject.org/events)
+Solid World is an opportunity to meet people who are interested in or currently working on Solid. If you missed Solid World you can [watch the recording here]().The [next Solid World](https://www.eventbrite.com/e/solid-world-tickets-115477011851?aff=erelexpmlt) will happen on the 3rd September 2020. 
+
+28th September 2020 - vitual event [Virtuele themanamiddag "Solid - de burger in regie van zijn gegevens](https://overheid.vlaanderen.be/opleiding/solid)
+
+### In Other News
+
+#### Solid Implementations
+* [TrinPod](https://graphmetrix.com/trinpod) is an industrial strength Pod provider with conceptual computing through Trinity AI Capable of handling a massive amount of data. Available next month. [Sign up now](https://graphmetrix.com/trinpod) for early access.
+
+#### Funding 
+* [NGI Atlantic](https://ngiatlantic.eu/ngiatlanticeu-2nd-open-call) - also check out the [NGI Twinning Lab](https://ngiatlantic.eu/twinning-lab?field_country_value=2&field_organisation_type_value=All&field_choose_the_ngi_topic_focus_value=All)
+
+#### Job Openings
+* [Digita](https://www.digita.ai/careers) is hiring a Full Stack Developer and a Linked Data Principal. Email tom@digita.ai for more information.
+* [Contact Inrupt careers](https://inrupt.com/careers) 
+
+### Update from the [Specification Editors](https://github.com/solid/process/blob/master/editors.md)

--- a/_posts/newsletter/2020-09-03-this-month-in-solid.md
+++ b/_posts/newsletter/2020-09-03-this-month-in-solid.md
@@ -10,7 +10,7 @@ categories: [Updates]
 ## Updates
 
 ### [Events](https://solidproject.org/events)
-Solid World is an opportunity to meet people who are interested in or currently working on Solid. If you missed Solid World you can [watch the recording here]().The [next Solid World]() will happen on the 1st October 2020. 
+Solid World is an opportunity to meet people who are interested in or currently working with Solid. If you missed Solid World you can [watch the recording here](#). The [next Solid World](#) will happen on the 1st October 2020. 
 
 28th September 2020 - virtual event [Virtuele themanamiddag "Solid - de burger in regie van zijn gegevens](https://overheid.vlaanderen.be/opleiding/solid)
 

--- a/_posts/newsletter/2020-09-03-this-month-in-solid.md
+++ b/_posts/newsletter/2020-09-03-this-month-in-solid.md
@@ -10,7 +10,7 @@ categories: [Updates]
 ## Updates
 
 ### [Events](https://solidproject.org/events)
-Solid World is an opportunity to meet people who are interested in or currently working on Solid. If you missed Solid World you can [watch the recording here]().The [next Solid World](https://www.eventbrite.com/e/solid-world-tickets-115477011851?aff=erelexpmlt) will happen on the 3rd September 2020. 
+Solid World is an opportunity to meet people who are interested in or currently working on Solid. If you missed Solid World you can [watch the recording here]().The [next Solid World]() will happen on the 1st October 2020. 
 
 28th September 2020 - vitual event [Virtuele themanamiddag "Solid - de burger in regie van zijn gegevens](https://overheid.vlaanderen.be/opleiding/solid)
 

--- a/_posts/newsletter/2020-09-03-this-month-in-solid.md
+++ b/_posts/newsletter/2020-09-03-this-month-in-solid.md
@@ -18,6 +18,7 @@ Solid World is an opportunity to meet people who are interested in or currently 
 
 #### Solid Implementations
 * [TrinPod](https://graphmetrix.com/trinpod) is an industrial strength Pod provider with conceptual computing through Trinity AI Capable of handling a massive amount of data. Available next month. [Sign up now](https://graphmetrix.com/trinpod) for early access.
+* [Walder](https://github.com/KNowledgeOnWebScale/walder) is a content management system that can be driven by one or multiple Pods
 
 #### Funding 
 * [NGI Atlantic](https://ngiatlantic.eu/ngiatlanticeu-2nd-open-call) - also check out the [NGI Twinning Lab](https://ngiatlantic.eu/twinning-lab?field_country_value=2&field_organisation_type_value=All&field_choose_the_ngi_topic_focus_value=All)

--- a/_posts/newsletter/2020-09-03-this-month-in-solid.md
+++ b/_posts/newsletter/2020-09-03-this-month-in-solid.md
@@ -12,7 +12,7 @@ categories: [Updates]
 ### [Events](https://solidproject.org/events)
 Solid World is an opportunity to meet people who are interested in or currently working on Solid. If you missed Solid World you can [watch the recording here]().The [next Solid World]() will happen on the 1st October 2020. 
 
-28th September 2020 - vitual event [Virtuele themanamiddag "Solid - de burger in regie van zijn gegevens](https://overheid.vlaanderen.be/opleiding/solid)
+28th September 2020 - virtual event [Virtuele themanamiddag "Solid - de burger in regie van zijn gegevens](https://overheid.vlaanderen.be/opleiding/solid)
 
 ### In Other News
 


### PR DESCRIPTION
This edition needs a specification update from the editors, or for that section to be removed. 

The link for Solid World September will be included after the webinar. 

@KaiGilb if you have any further editions to the news on TrinPod then this would be the place to include it.