### PR TITLE
Fix legacy url redirects and typos

### DIFF
--- a/pages/implement.md
+++ b/pages/implement.md
@@ -2,16 +2,18 @@
 layout: page
 title: Implement
 permalink: implement
+redirect_from:
+  - /for-enterprises
 ---
 
-Are you in the business of apps, identification, or storage and interested in implementing Solid? 
+Are you in the business of apps, identification, or storage and interested in implementing Solid?
 
-We would love to hear about your specific needs and set up a call to talk about how to transition your existing code towards being Solid compliant. 
+We would love to hear about your specific needs and set up a call to talk about how to transition your existing code towards being Solid compliant.
 
 Let us know when you would be available via [info@solidproject.org](mailto:info@solidproject.org) and you will receive the dial in details and confirmation time.
 
-You can read more about Solid on the webpage and in depth FAQs in preparation. If you have any material on your needs please do send them over so we can understand the details in more depth before our call. 
+You can read more about Solid on the webpage and in depth FAQs in preparation. If you have any material on your needs please do send them over so we can understand the details in more depth before our call.
 
-You can find other companies and organisations who have [implemented Solid here]({{site.baseUrl}}/use-solid).
+You can find other companies and organisations who have [implemented Solid here]({{site.baseUrl}}/users/get-a-pod).
 
 See also: [Job Board]({{site.baseUrl}}/job-board), [Funding Options]({{site.baseUrl}}/funding).

--- a/pages/implement.md
+++ b/pages/implement.md
@@ -3,7 +3,7 @@ layout: page
 title: Implement
 permalink: implement
 redirect_from:
-  - /for-enterprises
+  - /for-enterprises/
 ---
 
 Are you in the business of apps, identification, or storage and interested in implementing Solid?

--- a/pages/use-solid.md
+++ b/pages/use-solid.md
@@ -3,7 +3,7 @@ layout: page
 title: Get a Pod
 permalink: /users/get-a-pod
 redirect_from:
-  - /use-solid
+  - /use-solid/
   - /users
 
 ---
@@ -11,15 +11,15 @@ redirect_from:
 # Get a Pod and a WebID
 Pods are where you store your data. Your WebID lets you login to Solid apps and Pods as well as letting you connect to other people using Solid.
 
-Once you get a Pod and WebID, you can 
-[develop your first application](/developers/tutorials/getting-started), 
+Once you get a Pod and WebID, you can
+[develop your first application](/developers/tutorials/getting-started),
 and check out some applications [developed by the community](/apps).
 
 ## How to pick a Provider
 
-Different providers may suit different people. 
+Different providers may suit different people.
 
-The legal identity of the provider will be an important factor in how your data is handled. Some providers may engage with third parties, for example, to host the data. Mapping out clearly who is involved in what element of the provision is an important step in picking your Pod. 
+The legal identity of the provider will be an important factor in how your data is handled. Some providers may engage with third parties, for example, to host the data. Mapping out clearly who is involved in what element of the provision is an important step in picking your Pod.
 
 Reading the Terms of the provider is a good way to understand the implications of picking that provider.
 
@@ -27,7 +27,7 @@ The geographical location of the legal entities involved and the physical locati
 
 <img class="illustration" src="{{site.baseurl}}/assets/img/single-sign-on.svg" alt="[]" />
 
-To recap, some questions you may want to consider are: 
+To recap, some questions you may want to consider are:
 -	Who is involved?
 -	Where are all the parties that are involved?
 -	Where is the data physically stored?
@@ -43,6 +43,6 @@ If you are a provider you can add your service to this list by emailing [info@so
 
 ## How to self-host your Pod
 
-The way to get most control of your data is to **self-host**. Self-hosting means that your data is physically stored on a hard drive you hold at home, and managed by [a software](/for-developers/pod-server) you run on your own machine. This way, you don't have to entrust any third party with your data. Currently, this option still requires some technical background, and it may not be suitable for everyone yet. 
+The way to get most control of your data is to **self-host**. Self-hosting means that your data is physically stored on a hard drive you hold at home, and managed by [a software](/for-developers/pod-server) you run on your own machine. This way, you don't have to entrust any third party with your data. Currently, this option still requires some technical background, and it may not be suitable for everyone yet.
 
-We would like to make self-hosting a more user-friendly option in the future. The great thing about Solid is the flexibility it offers: you can choose to outsource the work for now and pick a provider, and **move to self-hosting later** on when the tools are ready for you. 
+We would like to make self-hosting a more user-friendly option in the future. The great thing about Solid is the flexibility it offers: you can choose to outsource the work for now and pick a provider, and **move to self-hosting later** on when the tools are ready for you.

--- a/pages/use-solid/apps.md
+++ b/pages/use-solid/apps.md
@@ -11,7 +11,7 @@ These Solid-compatible apps will store your data on [your own Pod]({{site.baseUr
 # Solid Apps
 
 ## Show Case
-* [Media Kraken](https://noeldemartin.github.io/media-kraken/) let's you track your media and never miss a beat. 2020. [Noel De Martin](https://noeldemartin.com). [documentation](https://github.com/NoelDeMartin/media-kraken/tree/main/docs) and [source code](https://github.com/NoelDeMartin/media-kraken) which is under GNU General Public License v3.0. Give feedback about the app via [this thread](https://forum.solidproject.org/t/media-kraken-keep-track-of-your-media-in-your-pod/3333).
+* [Media Kraken](https://noeldemartin.github.io/media-kraken/) lets you track your media and never miss a beat. 2020. [Noel De Martin](https://noeldemartin.com). [documentation](https://github.com/NoelDeMartin/media-kraken/tree/main/docs) and [source code](https://github.com/NoelDeMartin/media-kraken) which is under GNU General Public License v3.0. Give feedback about the app via [this thread](https://forum.solidproject.org/t/media-kraken-keep-track-of-your-media-in-your-pod/3333).
 * [Solidarity](https://scenaristeur.github.io/solidarity/). [source code](https://github.com/scenaristeur/solidarity) is under [MIT License Copyright (c) 2019](https://github.com/scenaristeur/shighl/blob/master/LICENSE)[David Faveris](http://smag0.blogspot.com/2013/12/smag0-le-projet.html)
 * [Notepod](https://notepod.vincenttunru.com/) is a simple note-taking app that stores notes in your Solid Pod. It was created as a demonstration of how to create Solid apps — inspect [its commit messages](https://gitlab.com/vincenttunru/notepod/commits/master) for more detailed guidance on [reading data](https://gitlab.com/vincenttunru/notepod/commit/5c534abdd2d6ed18be8ddc256427fb7bc0baae71), [authenticating](https://gitlab.com/vincenttunru/notepod/commit/f42f8ae6e55f1a1996050d5061252b5ac615b5aa), and more.
 * [Poddit](https://vincenttunru.gitlab.io/poddit/). 2019. Vincent Tunru.
@@ -48,14 +48,14 @@ These Solid-compatible apps will store your data on [your own Pod]({{site.baseUr
 * [Twee-Fi](https://factsmission.github.io/twee-fi/) helps you review claims and rate trustworthiness of tweets. [Twee-Fi](https://github.com/factsmission/twee-fi) [MIT License Copyright (c) 2018](https://github.com/factsmission/twee-fi/blob/master/LICENSE) [FactsMission](https://factsmission.com)
 * [Mark Book](https://markbook.org) is for creating bookmarks. [Source code](https://github.com/melvincarvalho/solid-bookmark) [MIT License Copyright (c) 2018](https://github.com/melvincarvalho/solid-bookmark/blob/gh-pages/LICENSE) [Melvin Carvalho](https://github.com/melvincarvalho)
 
-## Movies 
-* [Media Kraken](https://noeldemartin.github.io/media-kraken/) let's you track your media and never miss a beat. 2020. [Noel De Martin](https://noeldemartin.com). [documentation](https://github.com/NoelDeMartin/media-kraken/tree/main/docs) and [source code](https://github.com/NoelDeMartin/media-kraken) which is under GNU General Public License v3.0. Give feedback about the app via [this thread](https://forum.solidproject.org/t/media-kraken-keep-track-of-your-media-in-your-pod/3333).
+## Movies
+* [Media Kraken](https://noeldemartin.github.io/media-kraken/) lets you track your media and never miss a beat. 2020. [Noel De Martin](https://noeldemartin.com). [documentation](https://github.com/NoelDeMartin/media-kraken/tree/main/docs) and [source code](https://github.com/NoelDeMartin/media-kraken) which is under GNU General Public License v3.0. Give feedback about the app via [this thread](https://forum.solidproject.org/t/media-kraken-keep-track-of-your-media-in-your-pod/3333).
 
 ## Project Management
 * [RiseFor Mobilisation](https://git.happy-dev.fr/startinblox/applications/risefor-mobilisation) (deployed as [Referendum Signons](https://referendum.signons.fr)) is an app for organising referenda; it uses Solid under the hood.
 * [Solidbase](https://app.solidbase.info) agricultural project management. [source code](https://lab.allmende.io/solidbase/solidbase) is under [GNU AGPL3 (c) 2017](https://lab.allmende.io/solidbase/solidbase/blob/master/LICENSE) [Allmende Lab](https://lab.allmende.io)
 
-## Blogs 
+## Blogs
 * [Concept](https://useconcept.art) ([GitHub](https://github.com/travis/concept)) is an embarrassingly simple clone of [notion.so](https://notion.so) built on Solid, currently in early alpha.
 * [Notepod](https://notepod.vincenttunru.com/) is a simple note-taking app that stores notes in your Solid Pod. [source code](https://github.com/Vinnl/notepod) by [Vincent Tunru](https://github.com/Vinnl)
 * [OEdit](https://edit.o.team) an editor app for raw files using the vs interface. [source code](https://github.com/jaxoncreed/o-edit) by [Jackson Morgan](https://github.com/jaxoncreed).
@@ -70,9 +70,9 @@ These Solid-compatible apps will store your data on [your own Pod]({{site.baseUr
 ## Health
 * [Solid Health](https://github.com/jasonpaulos/solid-health)
 
-## Geolocation 
+## Geolocation
 * [Solid LBS](https://github.com/SharonStrats/SOLIDLBSPrototype) (deployed as [Sigmafied](https://sigmafied.com)). 2019. [Sharon Statsianis](https://github.com/SharonStrats).
-* [Solid Geolocation Challenge Entries](https://arquisoft.github.io/course1920.html#SolidChallen2020) 
+* [Solid Geolocation Challenge Entries](https://arquisoft.github.io/course1920.html#SolidChallen2020)
 
 ## Other
 * [Spoggy](https://spoggy.herokuapp.com/)
@@ -108,12 +108,12 @@ These Solid-compatible apps will store your data on [your own Pod]({{site.baseUr
 * [SPARQL Fiddle](https://jeff-zucker.github.io/sparql-fiddle/) online fiddle to run SPARQL against  Pods. [Source code](https://github.com/jeff-zucker/sparql-fiddle) [MIT License Copyright (c) 2018](https://github.com/jeff-zucker/sparql-fiddle/blob/master/LICENSE) [Jeff Zucker](https://github.com/jeff-zucker)
 * [Warp](https://linkeddata.github.io/warp/) file browser. [Source code](https://github.com/linkeddata/warp) MIT License Copyright (c) 2014](https://github.com/linkeddata/warp/blob/gh-pages/LICENSE) [Andrei Samba](https://github.com/deiu)
 
-# Historical Solid Apps 
+# Historical Solid Apps
 * [Inbox](https://github.com/solid/solid-inbox) processes notifications. [Source code](https://github.com/solid/solid-inbox/)[MIT License Copyright (c) 2015](https://github.com/solid/solid-inbox/blob/gh-pages/LICENSE.md)[Andrei Sambra](https://github.com/deiu)
 
 # Apps inclusion and exclusion criteria
 
-The criteria for an app to be Solid-compatible are: 
+The criteria for an app to be Solid-compatible are:
 * If identifying users is necessary, they must be able to login using their WebID and pointing to the Identity Provider of their choice
 * Data consumed by the app should be fetched from Solid Pods if possible
 * Data generated by the app should be stored in Solid Pods

--- a/website-strategy.md
+++ b/website-strategy.md
@@ -16,6 +16,6 @@ solidproject.org is a hub for:
 | Users  | to provide an adequate overview of why and how to use Solid  |
 
 ## Three most important user paths
-1. Enterprises: https://solidproject.org/for-enterprises/ with aim to convince enterprises to implement Solid
-2. Developers: https://solidproject.org/for-developers/ with aim to start building an app
-3. Users: https://solidproject.org/use-solid/ with aim to start using an app
+1. Enterprises: https://solidproject.org/implement with aim to convince enterprises to implement Solid
+2. Developers: https://solidproject.org/developers with aim to start building an app
+3. Users: https://solidproject.org/users/get-a-pod with aim to start using an app

--- a/website-strategy.md
+++ b/website-strategy.md
@@ -1,21 +1,21 @@
-# solidproject.org website strategy 
+# solidproject.org website strategy
 
 solidproject.org is a hub for:
-* a single source of truth describing what Solid is (and is not) 
-* updates on the Solid specification work as govererned by the [agreed process](https://github.com/solid/process) 
-* listing developer tools offered by other parties to implement the Solid specification 
-* listing of implementation of the Solid specification into user products (i.e. apps, Pods, identity providers) 
-* news about Solid 
+* a single source of truth describing what Solid is (and is not)
+* updates on the Solid specification work as governed by the [agreed process](https://github.com/solid/process)
+* listing developer tools offered by other parties to implement the Solid specification
+* listing of implementation of the Solid specification into user products (i.e. apps, Pods, identity providers)
+* news about Solid
 
-## aim and target audience of website 
+## aim and target audience of website
 
 | Target Audience  | Aim |
 | ------------- | ------------- |
-| Enterprises  | to provide an adequate overview of why and how to implemnt Solid in their enteprise  |
+| Enterprises  | to provide an adequate overview of why and how to implement Solid in their enterprise  |
 | Developers | to provide an adequate overview of information to be able to implement Solid technically  |
 | Users  | to provide an adequate overview of why and how to use Solid  |
 
 ## Three most important user paths
-1. Enterprises: https://solidproject.org/for-enterprises/ with aim to convince enterprises to implement Solid 
-2. Developers: https://solidproject.org/for-developers/ with aim to start building an app 
-3. Users: https://solidproject.org/use-solid/ with aim to start using an app 
+1. Enterprises: https://solidproject.org/for-enterprises/ with aim to convince enterprises to implement Solid
+2. Developers: https://solidproject.org/for-developers/ with aim to start building an app
+3. Users: https://solidproject.org/use-solid/ with aim to start using an app


### PR DESCRIPTION
I've noticed some legacy urls that are not redirecting property, in particular this one: https://solidproject.org/use-solid/

There is an issue with Github Pages, because that url works properly running the site locally. The solution is to declare the `redirect_from` with a trailing slash, like it's already done with this url that isn't broken: https://solidproject.org/for-developers/

While I was at it, I've fixed some typos and removed some trailing whitespace :D (my editor settings do that automatically).