### PR TITLE
make solid init config viewable

### DIFF
--- a/_posts/developers/pod-server/2019-01-01-00_overview.md
+++ b/_posts/developers/pod-server/2019-01-01-00_overview.md
@@ -54,7 +54,7 @@ The Solid server will run as a local Web server. You can directly expose the por
 
 - Then, run the command `$ npm install -g solid-server`. After the init-command you'll be prompted a series of questions to configure the server:
 
-```
+```config
 $ solid init
 * ? Path to the folder you want to serve. Default is (./data) /var/www/your.host.example.org/data
 ? SSL port to run on. Default is (8443) 8443


### PR DESCRIPTION
d2020-11-13 t21:24
@Vinnl @NSeydoux
the `solid init` codeblock was black.
the config statement should have fixed that.