### PR TITLE
Make code colour white by default

### DIFF
--- a/_sass/rouge-themes/monokai.scss
+++ b/_sass/rouge-themes/monokai.scss
@@ -2,6 +2,9 @@
   Downloaded from https://jwarby.github.io/jekyll-pygments-themes/languages/ruby.html
   as per https://jekyllrb.com/docs/liquid/tags/#stylesheets-for-syntax-highlighting
  */
+// The following line was added manually, because code without an explicit
+// language specifier was black-on-black:
+.highlight { color: #fff; }
 .highlight pre { background-color: #272822; }
 .highlight .hll { background-color: #272822; }
 .highlight .c { color: #75715e } /* Comment */


### PR DESCRIPTION
It was turned black, which isn't great on a black background.

Fixes #419.

Compare step 6: [before](https://solidproject.org/developers/tutorials/getting-started) and [after](https://deploy-preview-421--solidproject-dot-org.netlify.app/developers/tutorials/getting-started).