### PR TITLE
Init Terms page including URI Persistence Policy

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -15,6 +15,8 @@
     link: "/labs"
   - name: FAQs
     link: "/faqs"
+  - name: Terms of Use
+    link: "/terms"
 - name: What's New
   sublinks:
   - name: This Month in Solid

--- a/pages/terms.md
+++ b/pages/terms.md
@@ -1,0 +1,33 @@
+---
+layout: page-no-toc
+title: "Terms of Use"
+permalink: terms
+---
+
+# Terms of Use
+
+## URI Persistence Policy
+
+Last modified: 2021-01-12
+
+When information is made available on the Web, it is important for the integrity of the Web, and the society based upon it, that the URIs used to reference information be used well into the future, and that the information persist as identified.
+
+To this end, the Solid Project hosts make the following pledge: that as far as they are able, for resources on the solidproject.org Web site which are declared (see below) to be persistent.
+
+Pledge:
+
+* The hosts will ensure that persistent resources continue to be available throughout the life of the Solid Project;
+* Where a persistent resource is modified, a change history will be archived though the archive will not necessarily be available publicly;
+* Should the Solid Project be disbanded, then any Web site will be granted the right to make a copy (at a different URI) of all public persistent resources so long as they are not modified and are preserved in their entirety and made available free of charge, and provided the same persistence policy is applied to these "historical mirrors." In such event, the original https://solidproject.org web site will be handed over for management to another organization only if that organization pledges to this policy or one considered more persistent.
+
+As of this note, persistent resources include:
+
+* The home page "https://solidproject.org/";
+* Those which start "https://solidproject.org/TR/"
+
+No representation is made about the persistence policies for any other information on the site.
+
+The intent is to set an example by reducing the failure of links due to clumsy management or inadequate commitment to information persistence, and to provide a stable reference base of information about Solid-related topics as a service to the community.
+
+Tim Berners-Lee
+2021-01-12

--- a/pages/terms.md
+++ b/pages/terms.md
@@ -23,6 +23,7 @@ Pledge:
 As of this note, persistent resources include:
 
 * The home page "https://solidproject.org/";
+* Those which start "https://solidproject.org/" immediately followed by four decimal digits;
 * Those which start "https://solidproject.org/TR/" immediately followed by four decimal digits.
 
 No representation is made about the persistence policies for any other information on the site.

--- a/pages/terms.md
+++ b/pages/terms.md
@@ -23,7 +23,7 @@ Pledge:
 As of this note, persistent resources include:
 
 * The home page "https://solidproject.org/";
-* Those which start "https://solidproject.org/TR/"
+* Those which start "https://solidproject.org/TR/" immediately followed by four decimal digits.
 
 No representation is made about the persistence policies for any other information on the site.
 

--- a/pages/terms.md
+++ b/pages/terms.md
@@ -8,7 +8,7 @@ permalink: terms
 
 ## URI Persistence Policy
 
-Last modified: 2021-01-12
+Last modified: 2021-01-25
 
 When information is made available on the Web, it is important for the integrity of the Web, and the society based upon it, that the URIs used to reference information be used well into the future, and that the information persist as identified.
 
@@ -29,5 +29,5 @@ No representation is made about the persistence policies for any other informati
 
 The intent is to set an example by reducing the failure of links due to clumsy management or inadequate commitment to information persistence, and to provide a stable reference base of information about Solid-related topics as a service to the community.
 
-Tim Berners-Lee
-2021-01-12
+Solid Project
+2021-01-25


### PR DESCRIPTION
This is an initial PR for the Terms page as per https://github.com/solid/solidproject.org/issues/437 .

It includes information about the URI Persistence Policy as per https://github.com/solid/solidproject.org/issues/247 . It is a pledge to have persistence for Solid technical reports published under `https://solidproject.org/TR/` (eg. https://github.com/solid/solidproject.org/issues/249 )

IANAL, so, perhaps best to start by addressing the type of Terms ie. "Terms of Use" or "Terms of Service" or "Terms and Conditions", or possible others. This PR uses: "Terms of Use".

Proposed path for the Terms resource is `https://solidproject.org/terms` -- but open to alternatives.

I propose that additional information about the Terms is made in subsequent PRs.