### PR TITLE
Update 2019-01-01-00_overview.md

### DIFF
--- a/_posts/developers/pod-server/2019-01-01-00_overview.md
+++ b/_posts/developers/pod-server/2019-01-01-00_overview.md
@@ -56,13 +56,13 @@ The Solid server will run as a local Web server. You can directly expose the por
 
 ```config
 $ solid init
-* ? Path to the folder you want to serve. Default is (./data) /var/www/your.host.example.org/data
+* ? Path to the folder you want to serve. Default is (./data) e.g. /var/www/your.host.example.org/data
 ? SSL port to run on. Default is (8443) 8443
-? Solid server uri (with protocol, hostname and port) https://your.host.example.org
+? Solid server uri (with protocol and hostname) https://your.host.example.org
 ? Enable WebID authentication Yes
 ? Serve Solid on URL path /
-? Path to the config directory (for example: /etc/solid-server) (./config) /var/www/your.host.example.org/config
-? Path to the config file (for example: ./config.json) (./config.json) /var/www/your.host.example.org/config.json
+? Path to the config directory (./config) e.g. /var/www/your.host.example.org/config
+? Path to the config file (./config.json) e.g. /var/www/your.host.example.org/config.json
 ? Path to the server metadata db directory (for users/apps etc) (./.db) /var/www/your.host.example.org/.db
 ? Path to the SSL private key in PEM format /etc/letsencrypt/live/your.host.example.org/privkey.pem
 ? Path to the SSL certificate key in PEM format /etc/letsencrypt/live/your.host.example.org/fullchain.pem


### PR DESCRIPTION
I suggest two small changes:

The first, to keep things consistent, was to delete the word port.  If the word port remains, then the example should be https://your.host.example.org:8443

The second, again to keep things consistent, was to remove /etc/solid-server.  That way the examples follow the same pattern. 

There are two other changes I might suggest later: The first, change .db to match the same pattern as the previous two, i.e. (./.db) e.g. /var/www/...

The second, at the very end, start server.  There should be at least two options, one using systemctl, the other using solid start.