### PR TITLE
small grammar fix to solid-events page

### DIFF
--- a/pages/solid-events.md
+++ b/pages/solid-events.md
@@ -6,7 +6,7 @@ permalink: /events
 
 # Solid Events
 
-Solid Events are an opportunity for people who are working on Solid or are interested in Solid to meet. Solid Events are run by people like you. If you are interested in coordinating a Solid Event near you, reach out to the Solid Manager at [info@solidproject.org](mailto:info@solidproject.org).
+Solid Events provide an opportunity to meet others who are working on Solid or are interested in Solid. Solid Events are run by people like you. If you are interested in coordinating a Solid Event near you, reach out to the Solid Manager at [info@solidproject.org](mailto:info@solidproject.org).
 
 
 <div class="message is-info">


### PR DESCRIPTION
Ugh - that dangling modifier ("to meet" at the end of the first sentence) -- I thought I could live with it (so that the site is a bit less formal) - but it just kept nagging at me -- as though it was modifying "people are interested in Solid to meet".  We all have our idiosyncrasies - sigh :(