### PR TITLE
Add link to solid-flask to developer tools

### DIFF
--- a/_posts/developers/apps/tools/2019-01-01-00_overview.md
+++ b/_posts/developers/apps/tools/2019-01-01-00_overview.md
@@ -24,8 +24,9 @@ Session, Profile, Inbox, Chat...
   * [Solid Shell](https://github.com/jeff-zucker/solid-shell) - command line, interactive shell, and batch processor for Solid document management
   * [Visualization Lab](https://github.com/theWebalyst/visualisation-lab) - an experimental visualisation workbench built using Svelte
 
+## <a name="libraries">Solid-specific libraries</a>
 
-## <a name="libraries">Solid-specific JavaScript Libraries</a>
+### JavaScript
 
 A typical Solid app will perform one or more of these functions using one of the associated libraries:
 
@@ -79,6 +80,10 @@ Beginning developers may want to start with one of the interface libraries which
      * [OIDC relying party](https://github.com/solid/oidc-rp)
      * [OIDC resource server auth](https://github.com/solid/oidc-rs)
      * [Solid CLI](https://github.com/solid/solid-cli) - token management for node/console
+
+### Python
+
+* [solid-flask](https://gitlab.com/agentydragon/solid-flask) - simple "Hello World" Flask app that can read private data from a Solid pod
 
 ## Related Tools
   * [EasyRDF converter](http://www.easyrdf.org/converter): Convert RDF from a syntax to another


### PR DESCRIPTION
solid-flask is currently very bare-bones, but it does implement basic required DPoP auth, which I didn't find implemented anywhere else in Python. If there's anyone else who wants to develop for Solid in Python, it might serve as an okay starting point.