### PR TITLE
Adding the Web::Solid::Auth tool

### DIFF
--- a/_posts/developers/apps/tools/2019-01-01-00_overview.md
+++ b/_posts/developers/apps/tools/2019-01-01-00_overview.md
@@ -81,6 +81,10 @@ Beginning developers may want to start with one of the interface libraries which
      * [OIDC resource server auth](https://github.com/solid/oidc-rs)
      * [Solid CLI](https://github.com/solid/solid-cli) - token management for node/console
 
+### Perl
+
+* [Web::Solid::Auth](https://metacpan.org/pod/Web::Solid::Auth) - a Perl Solid-OIDC client with a command line tool and example app
+
 ### Python
 
 * [solid-flask](https://gitlab.com/agentydragon/solid-flask) - simple "Hello World" Flask app that can read private data from a Solid pod


### PR DESCRIPTION
This is a Perl module to authenticate against Solid-OIDC and provides a command line tool to add DPoP authentication headers to curl.