### PR TITLE
Remove references to deprecated devtools

### DIFF
--- a/_posts/developers/apps/tools/2019-01-01-00_overview.md
+++ b/_posts/developers/apps/tools/2019-01-01-00_overview.md
@@ -62,7 +62,6 @@ Beginning developers may want to start with one of the interface libraries which
      * [Inrupt Solid JavaScript Client](https://github.com/inrupt/solid-client-js) - Data and access management manipulation by Inrupt
 
   * <a name="interface">**Interface & Components Libraries**</a>
-     * [Solid Angular SDK](https://github.com/inrupt/generator-solid-angular)
      * [Inrupt Solid React SDK](https://github.com/inrupt/solid-ui-react)
      * [Solid React Components for GraphQL-LD](https://github.com/rubensworks/solid-react-graphql-ld.js)
      * [Solid UI](https://github.com/solid/solid-ui)

--- a/_posts/developers/apps/tools/2020-01-25_overview.md
+++ b/_posts/developers/apps/tools/2020-01-25_overview.md
@@ -53,8 +53,6 @@ See also [this cheatsheet](https://vincenttunru.gitlab.io/tripledoc/docs/cheatsh
      * [Solid Rest](https://github.com/jeff-zucker/solid-rest) - Solid access to non-Solid spaces such as browser IndexedDB and Dropbox
 
   * <a name="interface">**Interface & Components Libraries**</a>
-     * [Solid Angular SDK](https://github.com/inrupt/generator-solid-angular)
-     * [Solid React SDK](https://github.com/inrupt/solid-react-sdk)
      * [Solid React Components](https://github.com/solid/react-components)
      * [Solid React Components for GraphQL-LD](https://github.com/rubensworks/solid-react-graphql-ld.js)
      * [Solid UI](https://github.com/solid/solid-ui)


### PR DESCRIPTION
I'm still not sure which devtools listing is the right one, but Inrupt has a number of project that are deprecated and thus shouldn't be recommended to people, so I just removed them from both.