### PR TITLE
Adds link to spring-solid-demo

### DIFF
--- a/_posts/developers/apps/tools/2019-01-01-00_overview.md
+++ b/_posts/developers/apps/tools/2019-01-01-00_overview.md
@@ -91,6 +91,10 @@ Beginning developers may want to start with one of the interface libraries which
 ### Rust
 
 * [solid-warp](https://gitlab.com/agentydragon/solid-warp) - simple example of authenticated reads/writes to a Solid pod
+
+### Spring + Kotlin
+
+* [spring-solid-demo](https://github.com/hzafar/solid-spring-demo) - simple example of Solid-OIDC using Spring and Kotlin
      
      
 ## Related Tools

--- a/_posts/developers/apps/tools/2019-01-01-00_overview.md
+++ b/_posts/developers/apps/tools/2019-01-01-00_overview.md
@@ -92,7 +92,7 @@ Beginning developers may want to start with one of the interface libraries which
 
 * [solid-warp](https://gitlab.com/agentydragon/solid-warp) - simple example of authenticated reads/writes to a Solid pod
 
-### Spring + Kotlin
+### Kotlin
 
 * [spring-solid-demo](https://github.com/hzafar/solid-spring-demo) - simple example of Solid-OIDC using Spring and Kotlin
      


### PR DESCRIPTION
This is a simple app illustrating how to implement Solid OIDC using Spring, and may serve as a useful point of reference for anyone else looking to build a Solid app in the Java/Kotlin ecosystem.