### PR TITLE
Add autolink-email plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "github-pages", group: :jekyll_plugins
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
+  gem "jekyll-autolink_email"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,9 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-autolink_email (0.1.0)
+      jekyll (~> 3.0)
+      rinku (~> 1.7.0)
     jekyll-avatar (0.7.0)
       jekyll (>= 3.0, < 5.0)
     jekyll-coffeescript (1.1.1)
@@ -232,6 +235,8 @@ GEM
     multipart-post (2.1.1)
     nokogiri (1.11.7-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.7-x86_64-linux)
+      racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
     octokit (4.21.0)
@@ -247,6 +252,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
+    rinku (1.7.3)
     rouge (3.26.0)
     ruby-enum (0.9.0)
       i18n
@@ -282,10 +288,12 @@ GEM
 PLATFORMS
   x86_64-darwin-18
   x86_64-darwin-20
+  x86_64-linux-musl
 
 DEPENDENCIES
   github-pages
   html-proofer
+  jekyll-autolink_email
   minima (~> 2.0)
   tzinfo (~> 2.0)
   tzinfo-data

--- a/_config.yml
+++ b/_config.yml
@@ -28,6 +28,7 @@ theme: minima
 plugins:
   - jekyll-feed
   - jekyll-redirect-from
+  - jekyll-autolink_email
   # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.


### PR DESCRIPTION
We have quite a few places where we're listing email address in a Markdown file, but have not explicitly turned them into a link. This plugin does that automatically for us. (We couldn't add that on GitHub Pages, but now that we're on Netlify, we're free to use any plugin we want :)

Compare e.g. https://deploy-preview-614--solidproject-dot-org.netlify.app/apps with https://solidproject.org/apps at the bottom of the page, where it says:

> Want to add an eligible Solid-compatible app to this list? Contact the Solid Manager via info@solidproject.org or submit a pull request.