### PR TITLE
trivial: remove LIT prefix to artifact generator

### DIFF
--- a/_posts/developers/apps/vocabularies/2019-01-01-04_quickstart-artifacts.md
+++ b/_posts/developers/apps/vocabularies/2019-01-01-04_quickstart-artifacts.md
@@ -22,7 +22,7 @@ const iri = rdf.type;
 ```
 However, an issue with these libraries is that, by their nature, they are limited to just the common, well-known vocabularies. What about your specific vocabulary, designed for your app? How can you make the terms described in that vocabulary easily reusable in your code (and easily reusable in the code of others who may wish to reuse the terms you've defined in your cool vocabulary)?
 
-The [LIT artifact generator](https://www.npmjs.com/package/@inrupt/artifact-generator) is a tool that takes any RDF vocabulary as input and automatically generates a nice source-code bundle (i.e. an artifact such as a Java JAR, or a JavaScript NPM module) that you can then easily use in your application. Let's see how it works.
+The [artifact generator](https://www.npmjs.com/package/@inrupt/artifact-generator) is a tool (*currently available as Alpha*) that takes any RDF vocabulary as input and automatically generates a source-code bundle (i.e. an artifact such as a Java JAR, or a JavaScript NPM module) that you can then use in your application. Let's see how it works.
 
 ### Generate the artifact
 
@@ -33,7 +33,7 @@ You can specify a local vocabulary file rather than an IRI if your vocabulary is
 
 ### Use the artifact
 
-In your application (TODO: provide git repo with demo app), simply `require` the generated output, and use your vocabulary terms directly:
+In your application (TODO: provide git repo with demo app), `require` the generated output and use your vocabulary terms directly:
 ```javascript
 const OBELISK = require("/path/to/generated/artifact/OBELISK")
 

--- a/_posts/developers/apps/vocabularies/2019-01-01-04_quickstart-artifacts.md
+++ b/_posts/developers/apps/vocabularies/2019-01-01-04_quickstart-artifacts.md
@@ -22,7 +22,11 @@ const iri = rdf.type;
 ```
 However, an issue with these libraries is that, by their nature, they are limited to just the common, well-known vocabularies. What about your specific vocabulary, designed for your app? How can you make the terms described in that vocabulary easily reusable in your code (and easily reusable in the code of others who may wish to reuse the terms you've defined in your cool vocabulary)?
 
-The [artifact generator](https://www.npmjs.com/package/@inrupt/artifact-generator) is a tool (*currently available as Alpha*) that takes any RDF vocabulary as input and automatically generates a source-code bundle (i.e. an artifact such as a Java JAR, or a JavaScript NPM module) that you can then use in your application. Let's see how it works.
+The [ArtifactGenerator](https://www.npmjs.com/package/@inrupt/artifact-generator) 
+is a tool (*currently available as Alpha*) that takes any RDF
+vocabulary as input and can generate multiple source-code bundles 
+(e.g., Java JAR, JavaScript NPM module, etc.) that you can then use in
+your application. Let's see how it works.
 
 ### Generate the artifact
 


### PR DESCRIPTION
Removed "LIT" from the artifact generator name + mark as Alpha + minor tweaks to remove unnecessary words like "nice" and "easily" and "simply"

https://deploy-preview-620--solidproject-dot-org.netlify.app/developers/vocabularies/code/quickstart#the-artifact-generator