### PR TITLE
improve accessibility of header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,42 +1,39 @@
-<header>
-  <nav class="navbar" role="navigation" aria-label="main navigation">
-    <div class="navbar-brand">
-      <a class="navbar-item" href="{{site.baseUrl}}/">
-        <img
-          src="{{ site.baseurl }}/assets/img/solid-emblem.svg"
-          alt="[Solid logo]"
-        />
-      </a>
-      <a class="navbar-item navbar-brand-name is-uppercase is-size-4" href="{{site.baseUrl}}/">
-        Solid
-      </a>
-    </div>
-  
-    <div id="header-navbar" class="navbar-menu is-hidden-mobile">
-      <div class="navbar-end is-hidden-mobile">
-        {% for item in site.data.navigation %}
+<header id="header-navbar" class="navbar">
+  <a class="navbar-brand navbar-item navbar-link is-arrowless" href="{{site.baseUrl}}/">
+    <img
+      src="{{ site.baseurl }}/assets/img/solid-emblem.svg"
+      alt=""
+    />
+    <span class="is-uppercase is-size-4">Solid</span>
+  </a>
+
+  <nav class="navbar-menu is-hidden-mobile">
+    <ul class="navbar-end">
+      {% for item in site.data.navigation %}
+        <li class="navbar-item has-dropdown is-hoverable is-size-6 is-size-5-tablet">
           {% if item.sublinks %}
-            <div class="navbar-item has-dropdown is-hoverable is-size-6 is-size-5-tablet is-hidden-mobile">
-              <a class="navbar-link is-size-6 is-size-5-tablet is-hidden-mobile">
-                {{ item.name }}
-              </a>
-              <div class="navbar-dropdown">
-                {% for menu in item.sublinks %}
+            <button
+              class="navbar-link is-size-6 is-size-5-tablet"
+              aria-haspopup="true"
+            >{{ item.name }}</button>
+            <ul class="navbar-dropdown">
+              {% for menu in item.sublinks %}
+                <li>
                   <a
-                    class="navbar-item is-size-6 is-size-5-tablet is-hidden-mobile" 
+                    class="navbar-item is-size-6 is-size-5-tablet" 
                     href="{{ menu.link }}"
                   >{{ menu.name }}</a>
-                {% endfor %}
-              </div>
-            </div>
+                </li>
+              {% endfor %}
+            </ul>
           {% else %}
             <a
-              class="navbar-item is-size-6 is-size-5-tablet is-hidden-mobile"
+              class="navbar-link is-size-6 is-size-5-tablet is-arrowless"
               href="{{ item.link }}"
             >{{ item.name }}</a>
           {% endif %}
-        {% endfor %}
-      </div>
-    </div>
+        </li>
+      {% endfor %}
+    </ul>
   </nav>
 </header>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -293,24 +293,28 @@ details > summary {
 }
 
 #header-navbar {
-  .has-dropdown {  
-    a {
-      background-color: $grey-dark;
-      color: white;
-      &:hover {
+  .navbar-brand img {
+    margin-right: 1.5em;
+  }
+  .navbar-link {
+    border: none;
+    background-color: transparent;
+  }
+  a {
+    color: white;
+    &:hover, &:focus {
+      color: $primary;
+    }
+  }
+  
+  .navbar-dropdown {
+    background-color: $grey-dark;
+    a.navbar-item {
+      &:hover, &:focus {
+        background-color: white;
         color: $primary;
       }
     }
-  
-    .navbar-dropdown {
-      background-color: $grey-dark;
-      a.navbar-item {
-        &:hover, &:focus {
-          background-color: white;
-          color: $primary;
-        }
-      }
-  
-    }
+
   }
 }


### PR DESCRIPTION
- allow keyboard navigation by making the dropdown nav-items focusable
- make the <nav> only wrap the navigation
- make the navigation items a nested list so that the current position is announced by screen readers
- combine the two home links (icon and brand name)
- remove superfluous role and aria-label on <nav>