### PR TITLE
Update 2019-01-01-00_overview.md

### DIFF
--- a/_posts/developers/pod-server/2019-01-01-00_overview.md
+++ b/_posts/developers/pod-server/2019-01-01-00_overview.md
@@ -88,7 +88,7 @@ to which **you and your apps can read and write**.
 
 ## Creating your own account {#account}
 To create your own account,
-visit [http://localhost:3000/idp/register](http://localhost:3000/idp/register).
+visit [http://localhost:3000/idp/register/](http://localhost:3000/idp/register/).
 <br>
 The server can then **host your Pod and WebID**.
 


### PR DESCRIPTION
The url to create your own account needs to have a trailing slash, it returns `InvalidRequest: invalid_request` otherwise.
Mentioned in 2.0.0 release notes: https://github.com/solid/community-server/blob/main/RELEASE_NOTES.md?plain=1#L21