### PR TITLE
Fixed typo in links to API Documentation

### DIFF
--- a/_posts/developers/apps/inrupt-tutorial/2020-11-06-00_first-app.md
+++ b/_posts/developers/apps/inrupt-tutorial/2020-11-06-00_first-app.md
@@ -207,9 +207,9 @@ your Solid profile.
 For more information on the functions:
 
 - [solid-client API](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/index.html)
-  - [getSolidDataset()](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/modules/resource_soliddataset.html#getsoliddataset)
+  - [getSolidDataset()](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/modules/resource_solidDataset.html#getsoliddataset)
   - [getThing()](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/modules/thing_thing.html#getthing)
-  - [saveSolidDatasetAt()](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/modules/resource_soliddataset.html#savesoliddatasetat)
+  - [saveSolidDatasetAt()](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/modules/resource_solidDataset.html#savesoliddatasetat)
   - [setStringNoLocale()](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/modules/thing_set.html#setstringnolocale)
   - [setThing()](https://docs.inrupt.com/developer-tools/api/javascript/solid-client/modules/thing_thing.html#setthing)
 


### PR DESCRIPTION
Two links in the API documentation returned a 404 (File not found).

These links appear to be case sensitive.