### PR TITLE
Fixed typo in links to API Documentation

### DIFF
--- a/_posts/developers/apps/inrupt-tutorial/2020-11-06-00_first-app.md
+++ b/_posts/developers/apps/inrupt-tutorial/2020-11-06-00_first-app.md
@@ -216,6 +216,6 @@ For more information on the functions:
 
 - [solid-client-authn-browser API](https://docs.inrupt.com/developer-tools/api/javascript/solid-client-authn-browser/index.html)
 
-  - [Session.login()](https://docs.inrupt.com/developer-tools/api/javascript/solid-client-authn-browser/classes/session.html#login)
+  - [Session.login()](https://docs.inrupt.com/developer-tools/api/javascript/solid-client-authn-browser/classes/Session.html#login)
 
-  - [Session.handleIncomingRedirect()](https://docs.inrupt.com/developer-tools/api/javascript/solid-client-authn-browser/classes/session.html#handleincomingredirect)
+  - [Session.handleIncomingRedirect()](https://docs.inrupt.com/developer-tools/api/javascript/solid-client-authn-browser/classes/Session.html#handleincomingredirect)


### PR DESCRIPTION
Two other links in the API documentation returned a 404 (File not found).

These links appear to be case sensitive.