### PR TITLE
Solid uses open standards

### DIFF
--- a/_posts/developers/apps/inrupt-tutorial/2020-11-06-00_first-app.md
+++ b/_posts/developers/apps/inrupt-tutorial/2020-11-06-00_first-app.md
@@ -20,6 +20,8 @@ This tutorial creates an introductory application that uses Inrupt's
 [JavaScript Client Libraries](https://github.com/inrupt/solid-client-js) to read
 and write your name to your user profile.
 
+Note that while this tutorial leverages JavaScript, Solid is built on top of [open standards](https://github.com/solid/solid#standards-used). Any technical platform that implements the same standards can interact with Solid. For more information, see the [Solid Spec](https://github.com/solid/solid-spec).
+
 This tutorial uses [npm](https://www.npmjs.com/get-npm) and [Parcel](https://parceljs.org/)
 to run the application locally on `localhost:1234`.
 

--- a/_posts/developers/apps/inrupt-tutorial/2020-11-06-00_first-app.md
+++ b/_posts/developers/apps/inrupt-tutorial/2020-11-06-00_first-app.md
@@ -20,7 +20,7 @@ This tutorial creates an introductory application that uses Inrupt's
 [JavaScript Client Libraries](https://github.com/inrupt/solid-client-js) to read
 and write your name to your user profile.
 
-Note that while this tutorial leverages JavaScript, Solid is built on top of [open standards](https://github.com/solid/solid#standards-used). Any technical platform that implements the same standards can interact with Solid. For more information, see the [Solid Spec](https://github.com/solid/solid-spec).
+Note:  Although this tutorial uses Inrupt's JavaScript libraries, you can use other libraries (be it for JavaScript or other languages) that support Solid. For more information, see the [Solid Developer Tools & Libraries](https://solidproject.org/developers/tools/).
 
 This tutorial uses [npm](https://www.npmjs.com/get-npm) and [Parcel](https://parceljs.org/)
 to run the application locally on `localhost:1234`.


### PR DESCRIPTION
I thought this note might be useful after misunderstanding [how to use Solid](https://forum.solidproject.org/t/net-c-dotnetrdf-for-solid/1687).

Specifically, a few weeks ago, when I was trying to get back into Solid, I was under the impression that the only real way to work with Solid was to use the JavaScript libraries, and set about trying to understand how Solid worked in order to go about building a specific .NET client library to interact with Solid pods.

After awhile, it dawned on me: It would be nice if up front it was clear that Solid is built on top of open standards, which many platforms (i.e. Python, .NET, PHP, etc.) already have libraries for standards that Solid implements (RDF, HTTP, OpenID Connect, etc). Thus you don't need the Inrupt JavaScript libraries to get started - as long as you understand the spec and how it works, you can go about writing front ends in the technical platform(s) of your choice.