### PR TITLE
add reference to open spec

### DIFF
--- a/_posts/developers/apps/tools/2019-01-01-00_overview.md
+++ b/_posts/developers/apps/tools/2019-01-01-00_overview.md
@@ -121,7 +121,7 @@ Beginning developers may want to start with one of the interface libraries which
      * [EasyRDF](http://www.easyrdf.org/)
 
 ## Don't see your language?
-Solid is built on top of [open standards](https://github.com/solid/solid#standards-used). Any platform that implements the same standards can interact with Solid. For more information, see the [Solid Spec](https://github.com/solid/solid-spec).
+Solid is built on top of open standards. Any platform that leverages the various open technologies that Solid uses can interact with Solid. For more information, please refer to the [spec](https://solidproject.org/TR/protocol).
 
 ## <a name="contribute">How to contribute</a>
 

--- a/_posts/developers/apps/tools/2019-01-01-00_overview.md
+++ b/_posts/developers/apps/tools/2019-01-01-00_overview.md
@@ -120,6 +120,9 @@ Beginning developers may want to start with one of the interface libraries which
 
      * [EasyRDF](http://www.easyrdf.org/)
 
+## Don't see your language?
+Solid is built on top of [open standards](https://github.com/solid/solid#standards-used). Any platform that implements the same standards can interact with Solid. For more information, see the [Solid Spec](https://github.com/solid/solid-spec).
+
 ## <a name="contribute">How to contribute</a>
 
 If you have a new tool or library, or have suggested additions or changes for this page, please [submit a PR](https://github.com/solid/solidproject.org/tree/main/_posts/developers/apps/tools/2019-01-01-00_overview.md) or [contact the solidproject.org team](mailto:contact@solidproject.org). 


### PR DESCRIPTION
As a follow on to [PR 161](https://github.com/solid/solidproject.org/pull/671) - requesting a note to be added to this page near the end to encourage developers to reference the standards that Solid uses. This way if the language of their choice is not listed; they still may be able to interact with Solid if their language has frameworks already in place to work with HTTP, OIDC, etc.

I don't know that I'm the greatest wordsmith, so happy to accept other changes here.