### PR TITLE
 Remove editor-specific things from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,3 @@ _site
 
 vendor
 .bundle
-
-.DS_Store
-
-# IntelliJ
-.idea/
-*.iml


### PR DESCRIPTION
This MR removes non-project things from the `.gitignore` file, such as OS and IDE specific files.

As requested by @kjetilk in https://github.com/solid/solidproject.org/pull/160#issuecomment-596570532.
Fixes  #162