### PR TITLE
Libraries: add Solid Client PHP

### DIFF
--- a/_posts/developers/apps/tools/2019-01-01-00_overview.md
+++ b/_posts/developers/apps/tools/2019-01-01-00_overview.md
@@ -99,7 +99,11 @@ Beginning developers may want to start with one of the interface libraries which
 ### Swift
 
 * [SolidAuthSwift](https://github.com/crspybits/SolidAuthSwift) - Authentication package for a Solid Pod
-     
+
+### PHP
+
+* [Solid Client PHP](https://github.com/dunglas/solid-client-php) - a PHP library for creating files and folders in Solid pods and implementing Solid OIDC, also contains a bundle for the [Symfony](https://symfony.com) and [API Platform](https://api-platform.com) frameworks.
+
 ## Related Tools
   * [EasyRDF converter](http://www.easyrdf.org/converter): Convert RDF from a syntax to another
   * [Prefix.cc](http://prefix.cc): Dereference prefixes into their full domain name


### PR DESCRIPTION
Adds [Solid Client PHP](https://github.com/dunglas/solid-client-php) (see also [the related presentation](https://dunglas.fr/2022/04/building-decentralized-web-apps-with-solid-and-php/)).