### PR TITLE
Update 2020-11-06-00_first-app.md and package files to remove deprecated parcel-bundler package

### DIFF
--- a/_posts/developers/apps/inrupt-tutorial/2020-11-06-00_first-app.md
+++ b/_posts/developers/apps/inrupt-tutorial/2020-11-06-00_first-app.md
@@ -81,7 +81,7 @@ npm install @inrupt/solid-client @inrupt/solid-client-authn-browser @inrupt/voca
 1. Use `npm` to install `Parcel`:
 
     ```shell
-    npm install parcel-bundler
+    npm install parcel
     ```
 
 1. Edit the `package.json` file to list the browsers supported by
@@ -148,7 +148,7 @@ In the `my-demo-app` directory, create the files for the application.
 1. In the ``my-demo-app`` directory, run:
 
     ```shell
-    npx parcel index.html
+    npm start
     ```
 
     The output should resemble the following:

--- a/_posts/developers/apps/inrupt-tutorial/codesandbox/index.html
+++ b/_posts/developers/apps/inrupt-tutorial/codesandbox/index.html
@@ -4,7 +4,7 @@
       <head>
         <meta charset="utf-8" />
         <title>Getting Started: Inrupt JavaScript Client Libraries</title>
-        <script defer src="./index.js"></script>
+        <script type="module" defer src="./index.js"></script>
         <link rel="stylesheet" href="my-demo.css" />
       </head>
 

--- a/_posts/developers/apps/inrupt-tutorial/codesandbox/package.json
+++ b/_posts/developers/apps/inrupt-tutorial/codesandbox/package.json
@@ -24,6 +24,18 @@
     "@inrupt/vocab-common-rdf": "^0.6.0"
   },
   "devDependencies": {
-    "parcel-bundler": "^1.12.4"
+    "assert": "^2.0.0",
+    "browserify-zlib": "^0.2.0",
+    "buffer": "^5.7.1",
+    "console-browserify": "^1.2.0",
+    "crypto-browserify": "^3.12.0",
+    "parcel": "^2.8.3",
+    "punycode": "^1.4.1",
+    "querystring-es3": "^0.2.1",
+    "stream-browserify": "^3.0.0",
+    "stream-http": "^3.2.0",
+    "string_decoder": "^1.3.0",
+    "url": "^0.11.0",
+    "util": "^0.12.5"
   }
 }


### PR DESCRIPTION
Parcel-bundler package is now deprecated, this update seeks to remove the deprecated package and replace it with the new one. A part of this means explicitly installing packages that were used for pollyfilling (these would have been installed automatically anyway).