### PR TITLE
reorg-part2: remove/redirect older pages

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,50 +1,44 @@
 - name: Home
   link: "/"
   sublinks:
-  - name: About Solid
-    link: "/about"
-  - name: Using Solid
-    link: "/users"
-  - name: Get a Pod
-    link: "/users/get-a-pod"
-  - name: Solid Apps
-    link: "/apps"
-  - name: Team
-    link: "/team"
-  - name: Research Labs
-    link: "/labs"
-  - name: FAQs
-    link: "/faqs"
-  - name: Terms of Use
-    link: "/terms"
-  - name: Code of Conduct
-    link: "https://github.com/solid/process/blob/main/code-of-conduct.md"
+    - name: About Solid
+      link: "/about"
+    - name: Using Solid
+      link: "/users"
+    - name: Get a Pod
+      link: "/users/get-a-pod"
+    - name: Solid Apps
+      link: "/apps"
+    - name: Team
+      link: "/team"
+    - name: FAQs
+      link: "/faqs"
+    - name: Terms of Use
+      link: "/terms"
+    - name: Code of Conduct
+      link: "https://github.com/solid/process/blob/main/code-of-conduct.md"
 - name: What's New
   sublinks:
-  - name: This Month in Solid
-    link: "/newsletter"
-  - name: Solid Events
-    link: "/events"
-  - name: Press
-    link: "/press"
+    - name: This Month in Solid
+      link: "/newsletter"
+    - name: Solid Events
+      link: "/events"
+    - name: Press
+      link: "/press"
 - name: Developers
   link: "/developers"
   sublinks:
-  - name: Getting Started
-    link: "/developers/tutorials/getting-started"
-  - name: Self-hosting
-    link: "/self-hosting"
-  - name: Funding
-    link: "/funding"
-  - name: Forum
-    link: "https://forum.solidproject.org"
+    - name: Getting Started
+      link: "/developers/tutorials/getting-started"
+    - name: Forum
+      link: "https://forum.solidproject.org"
 - name: More
   sublinks:
-  - name: Specification
-    link: "/specification"
-  - name: License
-    link: "/license"
-  - name: Logo usage guidelines
-    link: "/logo-usage-guidelines"
-  - name: Website feedback
-    link: "https://github.com/solid/solidproject.org/issues/new"
+    - name: Specification
+      link: "/specification"
+    - name: License
+      link: "/license"
+    - name: Logo usage guidelines
+      link: "/logo-usage-guidelines"
+    - name: Website feedback
+      link: "https://github.com/solid/solidproject.org/issues/new"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -2,31 +2,29 @@
   link: /about
 - name: Developers
   sublinks:
-  - name: Getting Started
-    link: "/developers/tutorials/getting-started"
-  - name: Solid Tools and Libraries
-    link: "/developers/tools"
-  - name: Solid Apps
-    link: "/apps"
-  - name: Vocabularies Overview
-    link: "/developers/vocabularies"
+    - name: Getting Started
+      link: "/developers/tutorials/getting-started"
+    - name: Solid Tools and Libraries
+      link: "/developers/tools"
+    - name: Solid Apps
+      link: "/apps"
 - name: Users
   sublinks:
-  - name: Getting a Pod
-    link: /users/get-a-pod
-  - name: Solid Apps
-    link: "/apps"
+    - name: Getting a Pod
+      link: /users/get-a-pod
+    - name: Solid Apps
+      link: "/apps"
 - name: Community
   sublinks:
-  - name: Newsletter
-    link: /newsletter
-  - name: Events
-    link: /events
-  - name: Solid Forum
-    link: "https://forum.solidproject.org/"
-  - name: Chat
-    link: "https://app.element.io/#/room/!vUYWTYtHqQmtlhthvy:matrix.org"
-  - name: Press
-    link: /press
-  - name: Code of Conduct
-    link: "https://github.com/solid/process/blob/main/code-of-conduct.md"
+    - name: Newsletter
+      link: /newsletter
+    - name: Events
+      link: /events
+    - name: Solid Forum
+      link: "https://forum.solidproject.org/"
+    - name: Chat
+      link: "https://app.element.io/#/room/!vUYWTYtHqQmtlhthvy:matrix.org"
+    - name: Press
+      link: /press
+    - name: Code of Conduct
+      link: "https://github.com/solid/process/blob/main/code-of-conduct.md"

--- a/_includes/toc-about.html
+++ b/_includes/toc-about.html
@@ -1,10 +1,9 @@
 <ul class="menu-list" role="navigation">
   <li><a href="{{site.baseurl}}/about">About Solid</a>
     <ul>
-      <li><a href="{{site.baseurl}}/specification">Specification</a></li> 
-      <li><a href="{{site.baseurl}}/contributing">Contribute</a></li>               
-      <li><a href="{{site.baseurl}}/origin">Origin</a></li>        
-      <li><a href="{{site.baseurl}}/team">Team</a></li>        
+      <li><a href="{{site.baseurl}}/specification">Specification</a></li>
+      <li><a href="{{site.baseurl}}/contributing">Contribute</a></li>
+      <li><a href="{{site.baseurl}}/team">Team</a></li>
     </ul>
-  </li>  
+  </li>
 </ul>

--- a/pages/funding.md
+++ b/pages/funding.md
@@ -2,23 +2,25 @@
 layout: page-no-toc
 title: "Funding"
 permalink: funding
+redirect_to: https://github.com/solid/solidproject.org/wiki/Funding
 ---
 
 # Funding
+
 If you know of any grants or channels to apply to resources that would allow developers to focus on building their Solid applications, please do share them on this list by [submitting a pull request](https://github.com/solid/solidproject.org/blob/main/pages/funding.md) or by emailing the Solid Manager on info@solidproject.org.
 
-* [Consensus Community Innovation Grants](http://agree.org/)
-* [DuckDuckGo Donations](https://duckduckgo.com/donations)
-* [EU DAPSI](https://dapsi.ngi.eu/)
-* [GitHub Sponsors](https://github.com/sponsors)
-* [Grant for the web](https://forum.grantfortheweb.org/t/call-for-proposals-early-2020/959) 
-* [Je Data de Baas](https://www.sidnfonds.nl/nieuws/follow-up-call-je-data-de-baas) by SIDN
-* [Ledger Project](https://ledgerproject.eu)
-* [Mozilla Open Science Mini Grants](https://docs.google.com/document/d/1EJXg9G01CG7dBRbmbZzFnB9Bex2ibAVza_4xE8iqQqI/edit)
-* [Mozilla Open Source Support](https://www.mozilla.org/en-US/moss/)
-* [NGI Pointer](https://www.ngi.eu/ngi-projects/ngi-pointer/)
-* [NLNET Foundation](https://nlnet.nl)
-* [Next Generation Internet](https://www.ngi.eu)
-* [SIDN Fonds](https://www.sidnfonds.nl/excerpt/)
-* [Slack Fund](https://slack.com/developers/fund)
-* [The Knight Foundation](https://knightfoundation.org) and [The Knight Foundation for Technology Innovation](https://knightfoundation.org/programs/technology)
+- [Consensus Community Innovation Grants](http://agree.org/)
+- [DuckDuckGo Donations](https://duckduckgo.com/donations)
+- [EU DAPSI](https://dapsi.ngi.eu/)
+- [GitHub Sponsors](https://github.com/sponsors)
+- [Grant for the web](https://forum.grantfortheweb.org/t/call-for-proposals-early-2020/959)
+- [Je Data de Baas](https://www.sidnfonds.nl/nieuws/follow-up-call-je-data-de-baas) by SIDN
+- [Ledger Project](https://ledgerproject.eu)
+- [Mozilla Open Science Mini Grants](https://docs.google.com/document/d/1EJXg9G01CG7dBRbmbZzFnB9Bex2ibAVza_4xE8iqQqI/edit)
+- [Mozilla Open Source Support](https://www.mozilla.org/en-US/moss/)
+- [NGI Pointer](https://www.ngi.eu/ngi-projects/ngi-pointer/)
+- [NLNET Foundation](https://nlnet.nl)
+- [Next Generation Internet](https://www.ngi.eu)
+- [SIDN Fonds](https://www.sidnfonds.nl/excerpt/)
+- [Slack Fund](https://slack.com/developers/fund)
+- [The Knight Foundation](https://knightfoundation.org) and [The Knight Foundation for Technology Innovation](https://knightfoundation.org/programs/technology)

--- a/pages/implement.md
+++ b/pages/implement.md
@@ -4,6 +4,7 @@ title: Implement
 permalink: implement
 redirect_from:
   - /for-enterprises/
+redirect_to: /
 ---
 
 Are you in the business of apps, identification, or storage and interested in implementing Solid?

--- a/pages/job-board.md
+++ b/pages/job-board.md
@@ -2,6 +2,7 @@
 layout: page
 title: "Job Board"
 permalink: job-board
+redirect_to: /
 ---
 
 # Job Board

--- a/pages/origin.md
+++ b/pages/origin.md
@@ -2,54 +2,55 @@
 layout: page-about
 title: Origin
 permalink: origin
+redirect_to: about
 ---
 
 # Origin
 
-Solid is a mid-course correction for the Web by its inventor, 
-[Sir Tim Berners-Lee](/team). It realizes Tim's original vision for the 
-Web as a medium for the secure, decentralized exchange of public 
+Solid is a mid-course correction for the Web by its inventor,
+[Sir Tim Berners-Lee](/team). It realizes Tim's original vision for the
+Web as a medium for the secure, decentralized exchange of public
 and private data.
 
 <img src="/assets/img/timbl-cern.jpg"/>
 
 ## Why fix the Web?
 
-The [first web browser](https://worldwideweb.cern.ch/) was also an editor. 
-The idea being that not only could everyone read content on the web, but 
-they could also help create it. It was 
+The [first web browser](https://worldwideweb.cern.ch/) was also an editor.
+The idea being that not only could everyone read content on the web, but
+they could also help create it. It was
 to be a collaborative space for everyone.
 
-However, when the first browser that popularized the web came along, called 
-Mosaic, it included multimedia and editing was taken out. It was considered 
-too difficult a problem. This change was the first curtailing of the web’s 
-promise and spawned an effort led by Tim and others to get the write 
-functionality back. It was dubbed the ‘read-write web’ and led to Richard 
-McManus' 
-[seminal article](https://web.archive.org/web/20181214015324/http://readwrite.com/2003/04/19/the_readwrite_w) 
+However, when the first browser that popularized the web came along, called
+Mosaic, it included multimedia and editing was taken out. It was considered
+too difficult a problem. This change was the first curtailing of the web’s
+promise and spawned an effort led by Tim and others to get the write
+functionality back. It was dubbed the ‘read-write web’ and led to Richard
+McManus'
+[seminal article](https://web.archive.org/web/20181214015324/http://readwrite.com/2003/04/19/the_readwrite_w)
 published in 2003.
 
-The issue with writing data, as Wikipedia and others have learned, is that you 
-need a degree of control over who can write what. That means you need to have 
-permissions to dictate what individuals can do to the data. And to have 
-permissions you need to have a system for identity - a way of uniquely 
+The issue with writing data, as Wikipedia and others have learned, is that you
+need a degree of control over who can write what. That means you need to have
+permissions to dictate what individuals can do to the data. And to have
+permissions you need to have a system for identity - a way of uniquely
 authenticating that an individual is who they purport to be.
 
-Of course the social networks solved this problem within their own systems 
-using their own specific identity and access control, but these were not 
+Of course the social networks solved this problem within their own systems
+using their own specific identity and access control, but these were not
 standard, not interoperable, and gave you no choice in what applications you
 could use to access that data. You had to have your entire personal
 or professional life within one silo for it to work. And since the Web
 is ubiquitous, these silos exist across the data spectrum, from social
-and medical to financial and civil. 
+and medical to financial and civil.
 
 When your data is siloed away from you:
 
-* You have hardly any visibility into what is being retained.
-* You have little control over how it is used, or who is using it. 
-* You have little choice in which applications you can use to access it.
-* It is hard to use as a cohesive unit, specifically because it is siloed,
-scattered across proprietary vendors, interfaces, and data formats.
+- You have hardly any visibility into what is being retained.
+- You have little control over how it is used, or who is using it.
+- You have little choice in which applications you can use to access it.
+- It is hard to use as a cohesive unit, specifically because it is siloed,
+  scattered across proprietary vendors, interfaces, and data formats.
 
 All of these factors combine to make it very hard to access all of your
 own data, and put it to work on your behalf.

--- a/pages/solid-labs.md
+++ b/pages/solid-labs.md
@@ -2,55 +2,61 @@
 layout: page-no-toc
 title: "Labs"
 permalink: labs
+redirect_to: https://github.com/solid/solidproject.org/wiki/Research-labs
 ---
 
 # Research Labs
 
-Several academic groups conduct research around Solid. If you are interested in being listed send an email to info@solidproject.org with a description of the research project and link to the website. 
+Several academic groups conduct research around Solid. If you are interested in being listed send an email to info@solidproject.org with a description of the research project and link to the website.
 
 ### [BBC R&D](https://www.bbc.co.uk/rd) - [A BBC for the data economy](https://www.bbc.co.uk/rd/projects/new-forms-value-bbc-data-economy)
 
-BBC R&D have been using Solid to power research into ways that the BBC can deliver new types of data-based services to inform, educate and entertain in ways that gives maximum respect to the agency and privacy of their audience. 
+BBC R&D have been using Solid to power research into ways that the BBC can deliver new types of data-based services to inform, educate and entertain in ways that gives maximum respect to the agency and privacy of their audience.
 
 Contact: [https://www.bbc.co.uk/rd/contacts](https://www.bbc.co.uk/rd/contacts)
 
-### [MIT](https://www.mit.edu) - [CSAIL DIG](http://dig.csail.mit.edu) 
-Boston, USA 
+### [MIT](https://www.mit.edu) - [CSAIL DIG](http://dig.csail.mit.edu)
 
-Solid started at the [Decentralized Information Group](http://dig.csail.mit.edu) of CSAIL at MIT. Research focuses include verifiable credentials, privacy-preserving data aggregation on the decentralised web and investigating decentralised management of health and fitness data. 
+Boston, USA
+
+Solid started at the [Decentralized Information Group](http://dig.csail.mit.edu) of CSAIL at MIT. Research focuses include verifiable credentials, privacy-preserving data aggregation on the decentralised web and investigating decentralised management of health and fitness data.
 
 Contact [Lalana Kagal](https://www.csail.mit.edu/person/lalana-kagal)
 
-### [Oxford University Computer Science Lab](http://www.cs.ox.ac.uk) - [Oxford Martin School's program on Ethical Web and Data Architectures](https://www.oxfordmartin.ox.ac.uk/ethical-web-and-data-architectures). 
+### [Oxford University Computer Science Lab](http://www.cs.ox.ac.uk) - [Oxford Martin School's program on Ethical Web and Data Architectures](https://www.oxfordmartin.ox.ac.uk/ethical-web-and-data-architectures).
 
-The work at the Oxford Martin School's program on Ethical Web and Data Architectures focuses on four themes: data autonomy, data privacy, algorithmic accountability, and data sharing. In 2020, a grant was received to architect new ethical data systems such as Solid. 
+The work at the Oxford Martin School's program on Ethical Web and Data Architectures focuses on four themes: data autonomy, data privacy, algorithmic accountability, and data sharing. In 2020, a grant was received to architect new ethical data systems such as Solid.
 
 Contact [Nigel Shadbolt](https://www.cs.ox.ac.uk/people/nigel.shadbolt/)
 
-### The [KNowledge on Web Scale (KNoWS)](https://knows.idlab.ugent.be/) group at [Ghent University](https://www.ugent.be/en) – [imec](https://www.imec-int.com/) 
-Ghent, Belgium 
+### The [KNowledge on Web Scale (KNoWS)](https://knows.idlab.ugent.be/) group at [Ghent University](https://www.ugent.be/en) – [imec](https://www.imec-int.com/)
+
+Ghent, Belgium
 
 Imec has been involved in Solid for several years, focusing on data interoperability, querying, scalability, and the developer experience. They are currently building the [Community Solid Server](https://github.com/CommunitySolidServer/CommunitySolidServer/).
 
 Contact [Ruben Verborgh](https://ruben.verborgh.org)
 
 ### [University of Oviedo](http://www.uniovi.es/en) - [WESO](http://www.weso.es)
+
 Oviedo, Spain
 
-Classes at WESO now have the tradition of a competition for the best Solid app produced during their course. 
+Classes at WESO now have the tradition of a competition for the best Solid app produced during their course.
 
 Contact [Jose Emilio Labra Gayo](http://labra.weso.es)
 
 ### [CERN](https://home.cern) - [CERN-Solid collaboration entry point](https://indico.cern.ch/category/11962/)
-Geneva, Switzerland 
 
-CERN is heavily involved in open source, and follows Solid work. 
+Geneva, Switzerland
+
+CERN is heavily involved in open source, and follows Solid work.
 
 Contact [Maria Dimou](http://dimou.web.cern.ch/dimou/)
 
 ### Open University - [Open Blockchain Group](https://blockchain.open.ac.uk/#covid-19)
+
 Milton Keynes, UK
 
-The Open University runs an experimental server and works on a COVID-19 immunity passport Solid app. 
+The Open University runs an experimental server and works on a COVID-19 immunity passport Solid app.
 
 Contact [Manoharan Ramachandran](http://kmi.open.ac.uk/people/member/manoharan-ramachandran)


### PR DESCRIPTION
Per [earlier May 24 meeting discussion](https://github.com/solid/team/blob/main/meetings/2023-05-24.md) -- 2nd part of the initial cleanup:

- Archive the funding page to the wiki and redirect to the wiki.
- Redirect the implement page and redirect to the home page.
- Archive the research labs page to the wiki and redirect to the wiki.
- Remove the origin page and redirect to the parent about page.
- Cleanup of footer/toc/menu for the removed/archived pages