### PR TITLE
Add python authentication libraries

### DIFF
--- a/_posts/developers/apps/tools/2019-01-01-00_overview.md
+++ b/_posts/developers/apps/tools/2019-01-01-00_overview.md
@@ -88,6 +88,8 @@ Beginning developers may want to start with one of the interface libraries which
 
 * [solid-flask](https://gitlab.com/agentydragon/solid-flask) - simple "Hello World" Flask app that can read private data from a Solid pod
 * [solid-file-python](https://github.com/twonote/solid-file-python) - a Python library for creating and managing files and folders in Solid pods
+* [solid-oidc-py](https://github.com/Otto-AA/solid-oidc-py/) - client authentication via Solid-OIDC
+* [solid-client-credentials-py](https://github.com/Otto-AA/solid-client-credentials-py/) - client authentication via client credentials 
 
 ### Rust
 


### PR DESCRIPTION
I've added the solid-oidc-py and solid-client-credentials-py libraries to the developer tools list. The solid-oidc-py library is still unstable, the solid-client-credentials-py should be pretty stable. But I think both could be useful for people looking there :)