### PR TITLE
Add sitemap section to website strategy

### DIFF
--- a/website-strategy.md
+++ b/website-strategy.md
@@ -19,3 +19,111 @@ solidproject.org is a hub for:
 1. Enterprises: https://solidproject.org/implement with aim to convince enterprises to implement Solid
 2. Developers: https://solidproject.org/developers with aim to start building an app
 3. Users: https://solidproject.org/users/get-a-pod with aim to start using an app
+
+## Sitemap
+
+The sitemap information is intended to help track URIs that are allocated to the resources under solidproject.org. The information *is* incomplete (as of 2024-03-05) and needs to be updated as content and URI strategy changes (see also https://github.com/solid/solidproject.org/issues/249 ). The table should take 2xx, 3xx, 4xx status codes into account for all assets, including documents and media files that are made available as well as that were available in the past ( redirect, not found, gone..).
+
+* url: URLs of the tracked resources
+* status: intended status code in response to `HTTP GET`
+* design: information about the design (including architectural, presentational, behavioural)  of the resource
+* note: supplementary notes
+
+| url | status | design | notes |
+| - | - | - | - |
+| https://solidproject.org/ | 200 | foo | bar |
+| https://solidproject.org/about | | | |
+| https://solidproject.org/apps | | | |
+| https://solidproject.org/assets/img/interoperability-tour.svg | 200 | | |
+| https://solidproject.org/assets/img/share-it-safely-tour.svg | 200 | | |
+| https://solidproject.org/assets/img/store-anything-tour.svg | 200 | | |
+| https://solidproject.org/assets/img/solid-emblem.svg | 200 | | |
+| https://solidproject.org/assets/img/solid-pod-tour.svg | 200 | | |
+| https://solidproject.org/contributing | | | |
+| https://solidproject.org/developers/ | | | |
+| https://solidproject.org/developers/tools/ | | | |
+| https://solidproject.org/developers/tutorials/getting-started | | | |
+| https://solidproject.org/ED/protocol | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/ED/qa | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/events | | | |
+| https://solidproject.org/faqs | | | |
+| https://solidproject.org/license | | | |
+| https://solidproject.org/logo-usage-guidelines | | | |
+| https://solidproject.org/newsletter | | | |
+| https://solidproject.org/newsletter/2020-04-09 | | | |
+| https://solidproject.org/newsletter/2020-05-07 | | | |
+| https://solidproject.org/newsletter/2020-06-04 | | | |
+| https://solidproject.org/newsletter/2020-07-02 | | | |
+| https://solidproject.org/newsletter/2020-08-06 | | | |
+| https://solidproject.org/newsletter/2020-09-03 | | | |
+| https://solidproject.org/newsletter/2020-10-01 | | | |
+| https://solidproject.org/newsletter/2020-11-05 | | | |
+| https://solidproject.org/newsletter/2020-12-03 | | | |
+| https://solidproject.org/newsletter/2021-01-07 | | | |
+| https://solidproject.org/newsletter/2021-02-04 | | | |
+| https://solidproject.org/newsletter/2021-03-11 | | | |
+| https://solidproject.org/newsletter/2021-04-08 | | | |
+| https://solidproject.org/newsletter/2021-05-06 | | | |
+| https://solidproject.org/newsletter/2021-06-10 | | | |
+| https://solidproject.org/newsletter/2021-07-08 | | | |
+| https://solidproject.org/newsletter/2021-08-12 | | | |
+| https://solidproject.org/newsletter/2021-09-09 | | | |
+| https://solidproject.org/newsletter/2021-10-14 | | | |
+| https://solidproject.org/newsletter/archive | | | |
+| https://solidproject.org/press | | | |
+| https://solidproject.org/specification | | | |
+| https://solidproject.org/team | | | |
+| https://solidproject.org/terms | 200 | | |
+| https://solidproject.org/this-week-in-solid/2019-07-18 | | | |
+| https://solidproject.org/this-week-in-solid/2019-07-25 | | | |
+| https://solidproject.org/this-week-in-solid/2019-08-01 | | | |
+| https://solidproject.org/this-week-in-solid/2019-08-08 | | | |
+| https://solidproject.org/this-week-in-solid/2019-08-15 | | | |
+| https://solidproject.org/this-week-in-solid/2019-08-22 | | | |
+| https://solidproject.org/this-week-in-solid/2019-08-29 | | | |
+| https://solidproject.org/this-week-in-solid/2019-09-05 | | | |
+| https://solidproject.org/this-week-in-solid/2019-09-12 | | | |
+| https://solidproject.org/this-week-in-solid/2019-09-19 | | | |
+| https://solidproject.org/this-week-in-solid/2019-09-26 | | | |
+| https://solidproject.org/this-week-in-solid/2019-10-03 | | | |
+| https://solidproject.org/this-week-in-solid/2019-10-10 | | | |
+| https://solidproject.org/this-week-in-solid/2019-10-17 | | | |
+| https://solidproject.org/this-week-in-solid/2019-10-24 | | | |
+| https://solidproject.org/this-week-in-solid/2019-10-31 | | | |
+| https://solidproject.org/this-week-in-solid/2019-11-07 | | | |
+| https://solidproject.org/this-week-in-solid/2019-11-14 | | | |
+| https://solidproject.org/this-week-in-solid/2019-11-21 | | | |
+| https://solidproject.org/this-week-in-solid/2019-11-28 | | | |
+| https://solidproject.org/this-week-in-solid/2019-12-05 | | | |
+| https://solidproject.org/this-week-in-solid/2019-12-12 | | | |
+| https://solidproject.org/this-week-in-solid/2019-12-18 | | | |
+| https://solidproject.org/this-week-in-solid/2020-03-05 | | | |
+| https://solidproject.org/this-week-in-solid/2020-03-12 | | | |
+| https://solidproject.org/this-week-in-solid/2020-03-19 | | | |
+| https://solidproject.org/this-week-in-solid/2020-03-26 | | | |
+| https://solidproject.org/this-week-in-solid/2020-04-01 | | | |
+| https://solidproject.org/TR | 200 | Should be 404 `TR/` is canonical | TODO: [issue](https://github.com/solid/solidproject.org/issues/514) |
+| https://solidproject.org/TR/ | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/2021/protocol-20211217 | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/2021/wac-20210711 | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/2022/acp-20220518 | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/2022/notifications-protocol-20220509 | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/2022/notifications-protocol-20221231 | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/2022/oidc-20220328 | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/2022/oidc-primer-20220328 | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/2022/protocol-20221231 | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/2022/wac-20220705 | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/2022/websocket-subscription-2021-20220509 | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/acp | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/notification-subscription-types | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/notifications-protocol | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/oidc | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/oidc-primer | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/protocol | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/protocol.timemap | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/wac | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/TR/wac.timemap | 200 | User-agent default. HTML+RDFa representation available | - |
+| https://solidproject.org/TR/websocket-subscription-2021 | 200 | Uses W3C specification design patterns | - |
+| https://solidproject.org/users/get-a-pod | | | |
+
+The table is alphabetically sorted by url.


### PR DESCRIPTION
Initial [sitemap](https://en.wikipedia.org/wiki/Site_map) towards https://github.com/solid/solidproject.org/issues/842 to give a view and track's site's assets, including documents and media files that are made available as well as that were available in the past ( redirect, not found, gone..). It can also help us better observe and ensure a [URI Template](https://github.com/solid/solidproject.org/issues/249) that can be followed. This data also helps with design plans, e.g., to specify intended design patterns, and other notes about the issues.