### PR TITLE
Work around events list being too wide

### DIFF
--- a/community.html
+++ b/community.html
@@ -178,6 +178,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2023-03-29-solid-world" id="2023-03-29-solid-world" rel="schema:hasPart" typeof="schema:Event">
@@ -274,6 +276,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2022-09-08-solid-world" id="2022-09-08-solid-world" rel="schema:hasPart" typeof="schema:Event">
@@ -330,6 +334,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2022-05-12-solid-world" id="2022-05-12-solid-world" rel="schema:hasPart" typeof="schema:Event">
@@ -386,6 +392,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2022-03-10-solid-world" id="2022-03-10-solid-world" rel="schema:hasPart" typeof="schema:Event">
@@ -494,6 +502,9 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
+
 
                       <li>
                         <dl about="#s2021-08-10-women-of-solid" id="2021-08-10-women-of-solid" rel="schema:hasPart" typeof="schema:Event">
@@ -550,6 +561,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2021-06-21-di2f:-decentralising-the-internet-with-ipfs-and-filecoin" id="2021-06-21-di2f:-decentralising-the-internet-with-ipfs-and-filecoin" rel="schema:hasPart" typeof="schema:Event">
@@ -606,6 +619,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2021-05-06-solid-world-may" id="2021-05-06-solid-world-may" rel="schema:hasPart" typeof="schema:Event">
@@ -662,6 +677,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2021-02-04-solid-world-february" id="2021-02-04-solid-world-february" rel="schema:hasPart" typeof="schema:Event">
@@ -758,6 +775,9 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
+
 
                       <li>
                         <dl about="#s2020-09-03-solid-world-september" id="2020-09-03-solid-world-september" rel="schema:hasPart" typeof="schema:Event">
@@ -814,6 +834,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2020-05-07-solid-world-may" id="2020-05-07-solid-world-may" rel="schema:hasPart" typeof="schema:Event">
@@ -870,6 +892,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2020-02-19-solid-oviedo" id="2020-02-19-solid-oviedo" rel="schema:hasPart" typeof="schema:Event">
@@ -926,6 +950,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2020-01-07-solid-khartoum" id="2020-01-07-solid-khartoum" rel="schema:hasPart" typeof="schema:Event">
@@ -1008,6 +1034,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2019-10-11-solid-copenhagen" id="2019-10-11-solid-copenhagen" rel="schema:hasPart" typeof="schema:Event">
@@ -1064,6 +1092,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2019-07-05-solid-san-jose" id="2019-07-05-solid-san-jose" rel="schema:hasPart" typeof="schema:Event">
@@ -1120,6 +1150,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2019-05-22-solid-london" id="2019-05-22-solid-london" rel="schema:hasPart" typeof="schema:Event">
@@ -1176,6 +1208,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2019-04-09-solid-san-jose" id="2019-04-09-solid-san-jose" rel="schema:hasPart" typeof="schema:Event">
@@ -1232,6 +1266,8 @@
                         </dl>
                       </li>
 
+                    </ul>
+                    <ul rel="schema:hasPart">
 
                       <li>
                         <dl about="#s2019-03-21-solid-boston" id="2019-03-21-solid-boston" rel="schema:hasPart" typeof="schema:Event">


### PR DESCRIPTION
I didn't know how to tell CSS to display 4 items per row, so I just created one `<ul>` per row of 4.
This is a workaround, when we find someone who can write the proper CSS for this we can revert these insertions.