### PR TITLE
Updated links in getting-started section

### DIFF
--- a/developers/tutorials/getting-started.html
+++ b/developers/tutorials/getting-started.html
@@ -244,7 +244,7 @@ For a list of existing Pod providers, see <a href="/users/get-a-pod#get-a-pod-fr
 <h2 id="developing-your-first-app">Developing your first app</h2>
 
 <p>Once you are set up with your own Pod and WebID,
-you’re ready to develop your own app. Various Solid client libraries may provide a tutorial for beginners; for example, Inrupt offers the <a href="https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/getting-started/">JS Client Library tutorial</a>, and O.Team offers the <a href="https://github.com/o-development/ldo/blob/main/documentation/solid-react-tutorial.md">Solid-React-LDO tutorial</a>.</p>
+you’re ready to develop your own app. Various Solid client libraries may provide a tutorial for beginners; for example, Inrupt offers the <a href="https://docs.inrupt.com/developer-tools/javascript/client-libraries/tutorial/getting-started/">JS Client Library tutorial</a>, and O.Team offers the <a href="https://ldo.js.org/guides/solid_react/">Solid-React-LDO tutorial</a>.</p>
 
 <h2 id="community-assistance">Community assistance</h2>
 
@@ -275,7 +275,7 @@ you’re ready to develop your own app. Various Solid client libraries may provi
 
       </article>
       <footer class="section is-small">
-        <a href="https://github.com/solid/solidproject.org/edit/main/_posts/developers/apps/inrupt-tutorial/2021-08-03-00_getting-started.md" class="button is-text">Edit this page on GitHub</a>
+        <a href="https://github.com/solid/solidproject.org/blob/main/developers/tutorials/getting-started.html" class="button is-text">Edit this page on GitHub</a>
       </footer>
     </div>
     <aside id="sidebar" class="column is-one-third is-hidden-mobile section">


### PR DESCRIPTION
Two links in the getting-started page are broken:
 - Link to the LDO tutorial
 - Link to "Edit on Github"