### PR TITLE
Fix docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
-jekyll:
-  image: jekyll/jekyll
-  command: jekyll serve --watch --incremental
-  ports:
-    - 4000:4000
-  volumes:
-    - .:/srv/jekyll
+services:
+  jekyll:
+    image: jekyll/jekyll
+    command: jekyll serve --watch --incremental
+    ports:
+      - 4000:4000
+    volumes:
+      - .:/srv/jekyll


### PR DESCRIPTION
The structure of the docker-compose is invalid.

This fixes it and allows easily running the website in a Docker container.

Dev workflow:

```bash
~/GitHub/solid ❯ git clone git@github.com:solid/solidproject.org.git
~/GitHub/solid ❯ cd solidproject.org/
~/GitHub/solid/solidproject.org ❯ docker compose up
```

The website gets built in `_site/` and is visible at `localhost:4000`; jekyll running in the container watches the directory and rebuilds on changes.
