### PR TITLE
Add support link to site pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -122,6 +122,7 @@
           <li><a href="/community.html" rel="rdfs:seeAlso">Community</a></li>
           <li><a href="https://github.com/solid/solidproject.org/blob/main/LICENSE.md/#">License</a></li>
           <li><a about="#i" href="https://github.com/solid/process/blob/main/code-of-conduct.md" rel="schema:ethicsPolicy">Code of Conduct</a></li>
+          <li><a href="https://service.theodi.org/help/1476250723">Support</a></li>
         </ul>
       </nav>
 

--- a/community.html
+++ b/community.html
@@ -4761,6 +4761,7 @@
               >Code of Conduct</a
             >
           </li>
+          <li><a href="https://service.theodi.org/help/1476250723">Support</a></li>
         </ul>
       </nav>
 

--- a/for-developers.html
+++ b/for-developers.html
@@ -557,6 +557,7 @@
               >Code of Conduct</a
             >
           </li>
+          <li><a href="https://service.theodi.org/help/1476250723">Support</a></li>
         </ul>
       </nav>
 

--- a/for-organizations.html
+++ b/for-organizations.html
@@ -220,6 +220,7 @@
           <li><a href="/community.html">Community</a></li>
           <li><a href="https://github.com/solid/solidproject.org/blob/main/LICENSE.md">License</a></li>
           <li><a href="https://github.com/solid/process/blob/main/code-of-conduct.md">Code of Conduct</a></li>
+          <li><a href="https://service.theodi.org/help/1476250723">Support</a></li>
         </ul>
       </nav>
 

--- a/for-users.html
+++ b/for-users.html
@@ -62,6 +62,7 @@
           <li><a href="/community.html">Community</a></li>
           <li><a href="https://github.com/solid/solidproject.org/blob/main/LICENSE.md">License</a></li>
           <li><a href="https://github.com/solid/process/blob/main/code-of-conduct.md">Code of Conduct</a></li>
+          <li><a href="https://service.theodi.org/help/1476250723">Support</a></li>
         </ul>
       </nav>
 

--- a/index.html
+++ b/index.html
@@ -92,6 +92,7 @@
           <li><a href="/community.html">Community</a></li>
           <li><a href="https://github.com/solid/solidproject.org/blob/main/LICENSE.md">License</a></li>
           <li><a href="https://github.com/solid/process/blob/main/code-of-conduct.md">Code of Conduct</a></li>
+          <li><a href="https://service.theodi.org/help/1476250723">Support</a></li>
         </ul>
       </nav>
 

--- a/terms.html
+++ b/terms.html
@@ -82,6 +82,7 @@
           <li><a href="/community.html">Community</a></li>
           <li><a href="https://github.com/solid/solidproject.org/blob/main/LICENSE.md">License</a></li>
           <li><a href="https://github.com/solid/process/blob/main/code-of-conduct.md">Code of Conduct</a></li>
+          <li><a href="https://service.theodi.org/help/1476250723">Support</a></li>
         </ul>
       </nav>
 


### PR DESCRIPTION
### Changes made
Updated the following files:
- about.html
- community.html
- for-developers.html
- for-organizations.html
- for-users.html
- index.html
- terms.html

### Why
- clear path to technical support

### Testing
- Verified locally, appears correctly on all updated pages. 
