### PR TITLE
Remove broken redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,2 @@
 /TR/* https://solid.github.io/specification/:splat 200
 /ED/* https://solid.github.io/specification/ED/:splat 200
-/TREE/* https://solid.github.io/specification/tree/protocol-v0.9.0/:splat 200


### PR DESCRIPTION
The redirect rule removed by this PR pointed https://solidproject.org/TREE/ to https://solid.github.io/specification/tree/protocol-v0.9.0/ (which does not exist anymore).

There is no other link to `/TREE/` under solidproject.org and any link existing elsewhere would have been giving `404` [for over 4 years](https://github.com/solid/specification/commit/ab077628e52efb9daa7fe9b3685e8e4e44f987df).

The Shape Trees spec now lives under its own domain https://shapetrees.org/TR/specification/.

For those reasons, the correct course of action is to remove this redirect.