### PR TITLE
remove inrupt.net and dev.inrupt.net from table (no more live)

### DIFF
--- a/users/get-a-pod.html
+++ b/users/get-a-pod.html
@@ -145,13 +145,6 @@
       <td><a href="https://inrupt.com/products/enterprise-solid-server/">ESS</a></td>
     </tr>
     <tr>
-      <td><a href="https://inrupt.net/">inrupt.net</a></td>
-      <td><a href="https://www.inrupt.com">Inrupt, Inc.</a></td>
-      <td><a href="https://aws.amazon.com">Amazon</a></td>
-      <td>USA</td>
-      <td><a href="https://github.com/solid/node-solid-server">NSS</a></td>
-    </tr>
-    <tr>
       <td><a href="https://solidcommunity.net/">solidcommunity.net</a></td>
       <td><a href="https://github.com/solid/solidcommunity.net_operations">Solid Project</a></td>
       <td><a href="https://www.digitalocean.com">Digital Ocean</a></td>
@@ -163,13 +156,6 @@
       <td><a href="https://gitlab.com/groups/solidweb.org/-/group_members">Solid Grassroots</a></td>
       <td><a href="https://www.hosteurope.de">Hosteurope</a></td>
       <td>France</td>
-      <td><a href="https://github.com/solid/node-solid-server">NSS</a></td>
-    </tr>
-    <tr>
-      <td><a href="https://dev.inrupt.net/">dev.inrupt.net</a></td>
-      <td><a href="https://www.inrupt.com">Inrupt, Inc.</a></td>
-      <td><a href="https://aws.amazon.com">Amazon</a></td>
-      <td>USA</td>
       <td><a href="https://github.com/solid/node-solid-server">NSS</a></td>
     </tr>
     <tr>


### PR DESCRIPTION
d2025-09-19 t11:31

remove https://inrupt.net and https://dev.inrupt.net from overview table because these two instances do not exist anymore