### PR TITLE
Solid developers documentation link

### DIFF
--- a/for_developers.html
+++ b/for_developers.html
@@ -50,6 +50,13 @@ breadcrumbs:
   </div>
 </section>
 
+<section resource="#solid_developers_documentation" inlist="" rel="hasPart" class="article-section">
+  <h2 id="solid_developers_documentation" property="name">Solid Developers Documentation</h2>
+  <div datatype="rdf:HTML" property="description">
+    <p>The <a href="https://dev.solidproject.org">Solid Developers Documentation</a> is a central place to learn about Solid development. You can also contribute tutorials through the corresponding <a href="https://github.com/solid/dev">solid/dev repository</a>.</p>
+  </div>
+</section>
+
 <section resource="#open_source_solid_apps" inlist="" rel="hasPart" class="article-section">
   <h2 id="open_source_solid_apps" property="name">Open Source Solid Apps</h2>
   <div datatype="rdf:HTML" property="description">


### PR DESCRIPTION
Add a link to the [Solid Developers documentation](https://dev.solidproject.org/).

See: https://deploy-preview-939--musical-sawine-26ffa9.netlify.app/for_developers#solid_developers_documentation