### PR TITLE
add AndroidSolidServices as a tool for native android developers

### DIFF
--- a/for_developers.html
+++ b/for_developers.html
@@ -53,6 +53,7 @@ breadcrumbs:
       <li><a href="https://nextcloud.hellofuture.be/s/nYYNwGceFSNotJY">Ember Solid</a> by Aad Versteden</li>
       <li><a href="https://docs.inrupt.com/sdk/javascript-sdk/tutorial">Javascript tutorial</a> by Inrupt</li>
       <li><a href="https://docs.inrupt.com/sdk/java-sdk/tutorial">Java tutorial</a> by Inrupt</li>
+      <li><a href="https://androidsolidservices.erfangholami.com">Android Solid Services tutorial</a> by <a href="https://github.com/erfangholami">Erfan Gholami</a></li>
     </ul>
   </div>
 </section>

--- a/for_developers/getting_started.html
+++ b/for_developers/getting_started.html
@@ -62,6 +62,18 @@ breadcrumbs:
     <li><strong><a href="https://virginiabalseiro.com/blog/solid-react-app-tutorial">solid-react-app-tutorial</a></strong></li>
 </ul>
 
+<p>Solid on Android — <a href="https://androidsolidservices.erfangholami.com/getting-started">tutorial</a>:</p>
+
+<ul>
+    <li><strong><a href="https://github.com/pondersource/Android-Solid-Services">Android Solid Services</a></strong> — a host application providing Solid identity management for Android. Developers can integrate with it in two ways:
+        <ul>
+            <li><strong>Solid Android API Library</strong> — directly communicates with a Solid pod using Solid-OIDC with DPoP support</li>
+            <li><strong>Solid Android Client Library</strong> — connects to the Android Solid Services app via IPC, delegating authentication and resource access to the host service</li>
+        </ul>
+        Both libraries support <strong>data modules</strong> — a structured way to read and write specific types of data on a pod (e.g. contacts). See <a href="https://github.com/pondersource/Solid-Contacts">Solid Contacts</a> as a case study using the Contacts data module with the Solid Android Client Library.
+    </li>
+</ul>
+
 <p>You can also look into the Solid apps at:</p>
 <ul>
     <li><a href="https://solidproject.org/apps">Solid Apps</a></li>

--- a/for_developers/tools.html
+++ b/for_developers/tools.html
@@ -142,6 +142,12 @@ Session, Profile, Inbox, Chat…</li>
   <li><a href="https://github.com/dunglas/solid-client-php">Solid Client PHP</a> - a PHP library for creating files and folders in Solid pods and implementing Solid OIDC, also contains a bundle for the <a href="https://symfony.com">Symfony</a> and <a href="https://api-platform.com">API Platform</a> frameworks.</li>
 </ul>
 
+<h3 id="android">Android</h3>
+
+<ul>
+  <li><a href="https://github.com/pondersource/Android-Solid-Services">Android Solid Services</a> - a host application providing Solid identity management for Android, enabling apps to connect to Solid pods via direct server communication (Solid Android API Library) or inter-process communication (Solid Android Client Library) for delegated authentication</li>
+</ul>
+
 <h2 id="related-tools">Related Tools</h2>
 <ul>
   <li><a href="http://www.easyrdf.org/converter">EasyRDF converter</a>: Convert RDF from a syntax to another</li>


### PR DESCRIPTION
Adding the AndroidSolidServices app and libraries as tools for native Android developers to integrate Solid into their applications. 