### PR TITLE
fix: add skip to main content link for keyboard users and assistive technologies

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="/assets/styles.css" />
   </head>
   <body vocab="http://schema.org/">
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <header class="header">
       <address class="homepage-link">
         <a href="/"><img alt="Solid logo" src="/assets/img/solid-emblem.svg" /> Solid</a>
@@ -53,7 +54,7 @@
         {% endfor %}
       </ol>
     </nav>{% endif %}
-    <main>
+    <main id="main-content" tabindex="-1">
 {{ content }}
     </main>
     <footer class="footer">

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -66,6 +66,20 @@ h2, h3, h4, h5, h6 {
 }
 
 /* Layout */
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 0;
+  z-index: 1001;
+  background-color: #202542;
+  color: #fff;
+  padding: 0.8rem 1.6rem;
+  border-radius: 0 0 4px 0;
+}
+
+.skip-link:focus {
+  left: 0;
+}
 main {
   background-color: #fff;
   color: #202542;


### PR DESCRIPTION
This PR adds a "Skip to main content" link as the first focusable element on every page, letting keyboard and screen-readers users bypass the repeated header/nav. The link is visually hidden until focused. Addresses WCAG 2.4.1 (Bypass Blocks, Level A).