### PR TITLE
fix: improve events calendar mobile layout

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -350,3 +350,28 @@ main > article h1 {
   height: 100%;
   border: 0;
 }
+
+/** Events page - Calendar table */
+.calendar-download-table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.calendar-download-table .ical-download-button {
+  width: fit-content;
+  white-space: nowrap;
+}
+
+/** Events page - embedded Open Web Calendar */
+.calendar-embed {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  width: 100%;
+}
+
+.calendar-embed iframe {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  display: block;
+}

--- a/events.html
+++ b/events.html
@@ -18,35 +18,37 @@ breadcrumbs:
   <h2 id="w3c_standardisation_and_extra_activities_calendars" property="name">W3C Standardisation and Extra Activities Calendars</h2>
   <div datatype="rdf:HTML" property="description">
     <p>The following calendars are a good way to find out about upcoming meetings and events related to W3C Solid Standardisation or other Solid related activities such as Conferences like the Solid Symposium, <a href="https://fosdem.org/"><abbr title="Free and Open source Software Developers' European Meeting">FOSDEM</abbr></a> or group calls such as the SolidOS meetings.</p>
-    <table>
-      <thead>
-        <tr>
-          <th>Calendar</th>
-          <th>Link</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><a href="https://www.w3.org/groups/wg/lws/calendar/">Linked Web Storage Working Group Calendar</a></td>
-          <td><a class="ical-download-button" href="https://www.w3.org/groups/wg/lws/calendar/export/">Download iCal</a></td>
-        </tr>
-        <tr>
-          <td><a href="https://www.w3.org/groups/cg/solid/calendar/">Solid Community Group Calendar</a></td>
-          <td><a class="ical-download-button" href="https://www.w3.org/groups/cg/solid/calendar/export/">Download iCal</a></td>
-        </tr>
-        <tr>
-          <td>Extra Solid events</td>
-          <td><a class="ical-download-button" href="https://calendar.google.com/calendar/ical/c_bfb1bff94af78734820e9fe79db6057dc445ae82fda9beb80b70cf67945df491%40group.calendar.google.com/public/basic.ics">Download iCal</a></td>
-        </tr>
-      </tbody>
-    </table>
+    <div class="calendar-download-table-wrapper">
+      <table class="calendar-download-table">
+        <thead>
+          <tr>
+            <th>Calendar</th>
+            <th>Link</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="https://www.w3.org/groups/wg/lws/calendar/">Linked Web Storage Working Group Calendar</a></td>
+            <td><a class="ical-download-button" href="https://www.w3.org/groups/wg/lws/calendar/export/">Download iCal</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://www.w3.org/groups/cg/solid/calendar/">Solid Community Group Calendar</a></td>
+            <td><a class="ical-download-button" href="https://www.w3.org/groups/cg/solid/calendar/export/">Download iCal</a></td>
+          </tr>
+          <tr>
+            <td>Extra Solid events</td>
+            <td><a class="ical-download-button" href="https://calendar.google.com/calendar/ical/c_bfb1bff94af78734820e9fe79db6057dc445ae82fda9beb80b70cf67945df491%40group.calendar.google.com/public/basic.ics">Download iCal</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </section>
 
 <section resource="#open_web_calendar" inlist="" rel="hasPart" class="article-section">
   <h2 id="open_web_calendar" property="name">Open Web Calendar</h2>
-  <div datatype="rdf:HTML" property="description">
-    <iframe id="open-web-calendar" title="Solid events calendar" style="background:url('https://raw.githubusercontent.com/niccokunzmann/open-web-calendar/master/static/img/loaders/circular-loader.gif') center center no-repeat;" src="https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fwww.w3.org%2Fgroups%2Fwg%2Flws%2Fcalendar%2Fexport%2F&amp;url=https%3A%2F%2Fwww.w3.org%2Fgroups%2Fcg%2Fsolid%2Fcalendar%2Fexport%2F&amp;url=https%3A%2F%2Fcalendar.google.com%2Fcalendar%2Fical%2Fc_bfb1bff94af78734820e9fe79db6057dc445ae82fda9beb80b70cf67945df491%2540group.calendar.google.com%2Fpublic%2Fbasic.ics" sandbox="allow-scripts allow-same-origin allow-top-navigation allow-downloads" allowTransparency="true" scrolling="no" frameborder="0" height="600px" width="100%"></iframe>
+  <div datatype="rdf:HTML" property="description" class="calendar-embed">
+    <iframe id="open-web-calendar" title="Solid events calendar" style="background:url('https://raw.githubusercontent.com/niccokunzmann/open-web-calendar/master/static/img/loaders/circular-loader.gif') center center no-repeat;" src="https://open-web-calendar.hosted.quelltext.eu/calendar.html?url=https%3A%2F%2Fwww.w3.org%2Fgroups%2Fwg%2Flws%2Fcalendar%2Fexport%2F&amp;url=https%3A%2F%2Fwww.w3.org%2Fgroups%2Fcg%2Fsolid%2Fcalendar%2Fexport%2F&amp;url=https%3A%2F%2Fcalendar.google.com%2Fcalendar%2Fical%2Fc_bfb1bff94af78734820e9fe79db6057dc445ae82fda9beb80b70cf67945df491%2540group.calendar.google.com%2Fpublic%2Fbasic.ics&amp;javascript=scheduler.locale.date.day_full%3D%5B%22Sun%22%2C%22Mon%22%2C%22Tue%22%2C%22Wed%22%2C%22Thu%22%2C%22Fri%22%2C%22Sat%22%5D%3Bscheduler.locale.date.day_short%3D%5B%22Sun%22%2C%22Mon%22%2C%22Tue%22%2C%22Wed%22%2C%22Thu%22%2C%22Fri%22%2C%22Sat%22%5D%3Bscheduler.updateView%28%29%3B" sandbox="allow-scripts allow-same-origin allow-top-navigation allow-downloads" allowTransparency="true" scrolling="no" frameborder="0" height="600px" width="100%"></iframe>
   </div>
 </section>
 


### PR DESCRIPTION
On smaller mobile screens, the Events page calendar view was cramped.
**Before**
<img width="466" height="817" alt="Screenshot 2026-07-22 at 11 06 11" src="https://github.com/user-attachments/assets/da6be9b4-f833-4c33-8f69-cc2280914930" />

This PR fixes the issue above
**After**
<img width="415" height="740" alt="Screenshot 2026-07-22 at 12 17 28" src="https://github.com/user-attachments/assets/b62c5fb7-1e05-40ec-b29b-569d3585655a" />
