### PR TITLE
fix: render current breadcrumb as a span instead of a link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,7 +47,7 @@
         <li><a href="/">Home</a></li>
         {% for breadcrumb in page.breadcrumbs %}
           {% if forloop.last %}
-            <li><a href="#" aria-current="page">{{ breadcrumb.title }}</a></li>
+            <li><span aria-current="page">{{ breadcrumb.title }}</span></li>
           {% else %}
             <li><a href="{{ breadcrumb.url }}">{{ breadcrumb.title }}</a></li>
           {% endif %}

--- a/assets/css/breadcrumb.css
+++ b/assets/css/breadcrumb.css
@@ -36,10 +36,10 @@
   display: flex;
 }
 
-.breadcrumb li a[href="#"] {
+.breadcrumb li [aria-current="page"] {
   color: #202542;
-  cursor: default;
-  pointer-events: none;
+  margin: 0 1rem 0 0;
+  padding: 0.3rem 0;
 }
 
 .breadcrumb li + li::before {


### PR DESCRIPTION
Addresses WCAG 4.1.2 (Name, Role, Value) and 2.4.4 (Link Purpose)(Level A).