### PR TITLE
Add missing Pod providers to Get a Pod

### DIFF
--- a/get_a_pod.html
+++ b/get_a_pod.html
@@ -122,7 +122,7 @@ breadcrumbs:
       <dl>
         <dt>Get a Pod</dt>
         <dd>
-          <a href="https://solid.openlinksw.com:8445/register">https://solid.openlinksw.com:8445/</a>
+          <a href="https://solid.openlinksw.com:8445/register">https://solid.openlinksw.com:8445/register</a>
         </dd>
         <dt>Organization</dt>
         <dd>

--- a/get_a_pod.html
+++ b/get_a_pod.html
@@ -16,6 +16,26 @@ breadcrumbs:
     <ul class="tiles">
     <li>
       <div class="tile-header">
+        <img src="/assets/img/solid-emblem.svg" alt="brolly.id logo" />
+        <h3 id="brolly_id">brolly.id</h3>
+      </div>
+      <dl>
+        <dt>Get a Pod</dt>
+        <dd>
+          <a href="https://www.brolly.id/">https://www.brolly.id/</a>
+        </dd>
+        <dt>Organization</dt>
+        <dd>
+          <a href="https://stucco.software/">Stucco Software</a>
+        </dd>
+        <dt>Hosting Location</dt>
+        <dd>
+          <a href="https://en.wikipedia.org/wiki/United_States">US</a>
+        </dd>
+      </dl>
+    </li>
+    <li>
+      <div class="tile-header">
         <img src="/assets/img/logo/igrant.jpeg" alt="Data Pod logo" />
         <h3 id="data_pod">Data Pod</h3>
       </div>
@@ -56,6 +76,26 @@ breadcrumbs:
     </li>
     <li>
       <div class="tile-header">
+        <img src="/assets/img/solid-emblem.svg" alt="privatedatapod.com logo" />
+        <h3 id="privatedatapod_com">privatedatapod.com</h3>
+      </div>
+      <dl>
+        <dt>Get a Pod</dt>
+        <dd>
+          <a href="https://privatedatapod.com/">https://privatedatapod.com/</a>
+        </dd>
+        <dt>Organization</dt>
+        <dd>
+          <a href="https://privatedatapod.com/">Pod42 LLC</a>
+        </dd>
+        <dt>Hosting Location</dt>
+        <dd>
+          <a href="https://en.wikipedia.org/wiki/United_States">US</a>
+        </dd>
+      </dl>
+    </li>
+    <li>
+      <div class="tile-header">
         <img alt="Redpencil.io logo" src="/assets/img/logo/redpencil.io.svg"/>
         <h3 id="redpencil_io">redpencil.io</h3>
       </div>
@@ -71,6 +111,26 @@ breadcrumbs:
         <dt>Hosting Location</dt>
         <dd>
           <a href="https://en.wikipedia.org/wiki/European_Union">EU</a>
+        </dd>
+      </dl>
+    </li>
+    <li>
+      <div class="tile-header">
+        <img src="/assets/img/solid-emblem.svg" alt="solid.openlinksw.com logo" />
+        <h3 id="solid_openlinksw_com">solid.openlinksw.com</h3>
+      </div>
+      <dl>
+        <dt>Get a Pod</dt>
+        <dd>
+          <a href="https://solid.openlinksw.com:8445/register">https://solid.openlinksw.com:8445/</a>
+        </dd>
+        <dt>Organization</dt>
+        <dd>
+          <a href="https://www.openlinksw.com/">OpenLink Software</a>
+        </dd>
+        <dt>Hosting Location</dt>
+        <dd>
+          <a href="https://en.wikipedia.org/wiki/United_States">US</a>
         </dd>
       </dl>
     </li>


### PR DESCRIPTION
Trawls the sources linked from #959 and adds the Pod providers that were missing from [Get a Pod](https://solidproject.org/get_a_pod).

Sources checked:

- [`solid/catalog`](https://github.com/solid/catalog) `catalog-data.ttl` (all `con:GeneralPurposePodService` entries)
- [ewingson's `pod-provider.ttl`](https://ewingson.solidcommunity.net/public/ttl/pod-provider.ttl) (40 entries, incl. deprecated ones)
- [solidontrixie.net](https://solidontrixie.net/) (27 entries)
- [solid/solid-llm-skills#16](https://github.com/solid/solid-llm-skills/issues/16)

## Added

Inclusion criterion applied: the service is reachable over HTTPS with a valid certificate, **and** a member of the public can register a Pod on it themselves today (registration endpoint verified as open, not disabled or invite-gated).

| Provider | Organization | Software | Location |
| --- | --- | --- | --- |
| [brolly.id](https://www.brolly.id/) | [Stucco Software](https://stucco.software/) (US 501(c)(3)) | — | US |
| [privatedatapod.com](https://privatedatapod.com/) | Pod42 LLC | CSS | US (AWS) |
| [solid.openlinksw.com](https://solid.openlinksw.com:8445/) | [OpenLink Software](https://www.openlinksw.com/) | OpenLink Solid Server 5.0.1 | US |

All three use `/assets/img/solid-emblem.svg` as their tile image, as several existing entries do — happy to swap in supplied logos.

OpenLink also runs a 4.x instance on `:8444`; only the current 5.x instance is listed, since it is the same provider.

## Checked and deliberately not added

<details>
<summary>Rationale per candidate</summary>

**Registration closed**
- `solid.aifb.kit.edu` (KIT) — CSS is up, but the register page returns "Sorry, you are not allowed to register a Pod at this Solid Server!"
- `solid.live` — JSS instance, but registration is invite-code-only.

**Not reachable**
- `pod.liquid.surf` — connection refused.
- `solid.social` — TLS certificate expired.

**No longer a Solid server**
- `solid.open.ac.uk` — now serves an unrelated WordPress site (STEM Research Archive).

**Not a public Pod service**
- `dev.solid.redpencil.io` — dev instance of the already-listed redpencil.io.
- `pivot-test.solidproject.org:8443` / `:3000` / `:3100` — test instances.
- `wiser-solid-xi.interactions.ics.unisg.ch` — research deployment (Univ. of St. Gallen).
- `solid-01.muze.nl` — in-house deployment.
- `nodezero.social` — a social app / testnet, not a general-purpose Pod service.

**Worth a separate discussion**
- [Mastopod](https://mastopod.com/) and [Startin'Blox](https://startinblox.com/) are typed `GeneralPurposePodService` in `solid/catalog`. Both are ActivityPods/SemApps-based; Mastopod has open registrations but exposes no Solid-OIDC configuration. Whether ActivityPods instances belong on this page is a call for the CG rather than something to decide in this PR.

</details>

## Note

#959 also flags that the **Solid Server implementations** section is incomplete (JSS, Pivot and others are missing). That is left for a follow-up so this PR stays scoped to Pod providers.

I could not run `jekyll build` locally (system Ruby is 2.6, and the Docker daemon was unavailable), so please check the deploy preview renders the three new tiles.
